### PR TITLE
Explicitly convert strings for WASM and JS

### DIFF
--- a/latex2mmlc/src/ast.rs
+++ b/latex2mmlc/src/ast.rs
@@ -57,7 +57,7 @@ pub enum Node {
     Slashed(Box<Node>),
 }
 
-const INDENT: &'static str = "    ";
+const INDENT: &str = "    ";
 
 macro_rules! push {
     ($buf:expr, $($s:expr),+ $(,)?) => {{

--- a/latex2mmlc_cli/src/main.rs
+++ b/latex2mmlc_cli/src/main.rs
@@ -70,12 +70,10 @@ fn main() {
                 }
                 Err(e) => Err(e),
             }
+        } else if args.recursive {
+            convert_html_recursive(fpath)
         } else {
-            if args.recursive {
-                convert_html_recursive(fpath)
-            } else {
-                convert_html(fpath)
-            }
+            convert_html(fpath)
         };
         if let Err(e) = result {
             eprintln!("LaTeX2MathML Error: {}", e);

--- a/latex2mmlc_python/src/lib.rs
+++ b/latex2mmlc_python/src/lib.rs
@@ -1,6 +1,7 @@
 use pyo3::create_exception;
 use pyo3::exceptions::PyException;
 use pyo3::prelude::*;
+use pyo3::types::PyString;
 
 use latex2mmlc::{latex_to_mathml, Display};
 
@@ -8,8 +9,13 @@ create_exception!(_latex2mmlc_rust, LatexError, PyException);
 
 /// Convert LaTeX equation to MathML.
 #[pyfunction]
-fn convert_latex(latex: &str, block: bool, pretty: bool) -> PyResult<String> {
-    latex_to_mathml(
+fn convert_latex<'a>(
+    py: Python<'a>,
+    latex: &str,
+    block: bool,
+    pretty: bool,
+) -> PyResult<&'a PyString> {
+    let result = latex_to_mathml(
         latex,
         if block {
             Display::Block
@@ -18,13 +24,14 @@ fn convert_latex(latex: &str, block: bool, pretty: bool) -> PyResult<String> {
         },
         pretty,
     )
-    .map_err(|latex_error| LatexError::new_err(latex_error.to_string()))
+    .map_err(|latex_error| LatexError::new_err(latex_error.to_string()))?;
+    Ok(PyString::new(py, &result))
 }
 
 /// A Python module implemented in Rust.
 #[pymodule]
-fn _latex2mmlc_rust(_py: Python, m: &PyModule) -> PyResult<()> {
-    m.add("LatexError", _py.get_type::<LatexError>())?;
+fn _latex2mmlc_rust(py: Python, m: &PyModule) -> PyResult<()> {
+    m.add("LatexError", py.get_type::<LatexError>())?;
     m.add_function(wrap_pyfunction!(convert_latex, m)?)?;
     Ok(())
 }

--- a/latex2mmlc_wasm/src/lib.rs
+++ b/latex2mmlc_wasm/src/lib.rs
@@ -6,7 +6,7 @@ use latex2mmlc::{latex_to_mathml, Display};
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
-pub fn convert(content: &str, block: bool, pretty: bool) -> Result<String, JsValue> {
+pub fn convert(content: &str, block: bool, pretty: bool) -> Result<JsValue, JsValue> {
     match latex_to_mathml(
         content,
         if block {
@@ -16,7 +16,7 @@ pub fn convert(content: &str, block: bool, pretty: bool) -> Result<String, JsVal
         },
         pretty,
     ) {
-        Ok(result) => Ok(result),
+        Ok(result) => Ok(JsValue::from_str(&result)),
         Err(e) => Err(JsValue::from_str(&e.string())),
     }
 }


### PR DESCRIPTION
This is a preparatory step for using a different allocator.