### PR TITLE
Implement custom fraction divider widths

### DIFF
--- a/latex2mmlc/src/error.rs
+++ b/latex2mmlc/src/error.rs
@@ -34,6 +34,7 @@ pub enum LatexErrKind<'source> {
         correct_place: Place,
     },
     ExpectedText(&'static str),
+    ExpectedLength(&'source str),
 }
 
 #[derive(Debug, AsRefStr)]
@@ -91,6 +92,7 @@ impl LatexErrKind<'_> {
                     + "."
             }
             LatexErrKind::ExpectedText(place) => "Expected text in ".to_string() + place + ".",
+            LatexErrKind::ExpectedLength(got) => "Expected length with units, got \"".to_string() + got.as_ref() + "\".",
         }
     }
 }

--- a/latex2mmlc/src/lib.rs
+++ b/latex2mmlc/src/lib.rs
@@ -248,6 +248,8 @@ mod tests {
                 r"\sum_{\genfrac{}{}{0pt}{}{\scriptstyle 0 \le i \le m}{\scriptstyle 0 < j < n}} P(i, j)",
             ),
             ("genfrac", r"\genfrac(]{0pt}{2}{a+b}{c+d}"),
+            ("genfrac_1pt", r"\genfrac(]{1pt}{2}{a+b}{c+d}"),
+            ("genfrac_1px", r"\genfrac(]{1px}{2}{a+b}{c+d}"),
             ("not_subset", r"\not\subset"),
             ("not_less_than", r"\not\lt"),
             ("not_less_than_symbol", r"\not< x"),

--- a/latex2mmlc/src/parse.rs
+++ b/latex2mmlc/src/parse.rs
@@ -208,7 +208,7 @@ where
                 let num = self.parse_single_token(true)?;
                 let den = self.parse_single_token(true)?;
                 if matches!(cur_token, Token::Binom(_)) {
-                    let lt = Some(Length(0));
+                    let lt = Some(Length::from_twip(0));
                     Node::Fenced {
                         open: ops::LEFT_PARENTHESIS,
                         close: ops::RIGHT_PARENTHESIS,

--- a/latex2mmlc/src/parse.rs
+++ b/latex2mmlc/src/parse.rs
@@ -236,14 +236,10 @@ where
                     _ => return Err(LatexError(0, LatexErrKind::UnexpectedEOF)),
                 };
                 self.check_lbrace()?;
-                // The default line thickness in LaTeX is 0.4pt.
-                // TODO: Support other line thicknesses.
-                // We could maybe store them as multiples of 0.4pt,
-                // so that we can render them as percentages.
                 let lt = match self.parse_text_group()?.trim() {
                     "" => None,
                     decimal => Some(Length::from_str(decimal)
-                        .map_err(|LengthParseError| LatexError(0, LatexErrKind::UnexpectedEOF))?),
+                        .map_err(|LengthParseError| LatexError(0, LatexErrKind::ExpectedLength(decimal)))?),
                 };
                 let style = match self.parse_token()? {
                     Node::Number(num) => match num.as_bytes() {

--- a/latex2mmlc/src/snapshots/latex2mmlc__tests__genfrac_1pt.snap
+++ b/latex2mmlc/src/snapshots/latex2mmlc__tests__genfrac_1pt.snap
@@ -1,11 +1,11 @@
 ---
 source: latex2mmlc/src/lib.rs
-expression: "\\genfrac(]{0pt}{2}{a+b}{c+d}"
+expression: "\\genfrac(]{1pt}{2}{a+b}{c+d}"
 ---
 <math>
     <mrow displaystyle="false" scriptlevel="1">
         <mo>(</mo>
-        <mfrac linethickness="0">
+        <mfrac linethickness="1pt">
             <mrow>
                 <mi>a</mi>
                 <mo>+</mo>

--- a/latex2mmlc/src/snapshots/latex2mmlc__tests__genfrac_1px.snap
+++ b/latex2mmlc/src/snapshots/latex2mmlc__tests__genfrac_1px.snap
@@ -1,11 +1,11 @@
 ---
 source: latex2mmlc/src/lib.rs
-expression: "\\genfrac(]{0pt}{2}{a+b}{c+d}"
+expression: "\\genfrac(]{1px}{2}{a+b}{c+d}"
 ---
 <math>
     <mrow displaystyle="false" scriptlevel="1">
         <mo>(</mo>
-        <mfrac linethickness="0">
+        <mfrac linethickness="1px">
             <mrow>
                 <mi>a</mi>
                 <mo>+</mo>

--- a/latex2mmlc/src/snapshots/latex2mmlc__tests__scriptstyle.snap
+++ b/latex2mmlc/src/snapshots/latex2mmlc__tests__scriptstyle.snap
@@ -7,7 +7,7 @@ expression: "\\sum_{\\genfrac{}{}{0pt}{}{\\scriptstyle 0 \\le i \\le m}{\\script
         <mo>∑</mo>
         <mrow>
             <mo></mo>
-            <mfrac linethickness="0pt">
+            <mfrac linethickness="0">
                 <mrow displaystyle="false" scriptlevel="1">
                     <mn>0</mn>
                     <mo>≤</mo>

--- a/latex2mmlc/src/snapshots/latex2mmlc__tests__simple_binomial_coefficient.snap
+++ b/latex2mmlc/src/snapshots/latex2mmlc__tests__simple_binomial_coefficient.snap
@@ -5,7 +5,7 @@ expression: "\\binom12"
 <math>
     <mrow>
         <mo>(</mo>
-        <mfrac linethickness="0pt">
+        <mfrac linethickness="0">
             <mn>1</mn>
             <mn>2</mn>
         </mfrac>

--- a/latex2mmlc/tests/snapshots/wiki_test__wiki120.snap
+++ b/latex2mmlc/tests/snapshots/wiki_test__wiki120.snap
@@ -5,7 +5,7 @@ expression: "\\binom{n}{k}"
 <math>
     <mrow>
         <mo>(</mo>
-        <mfrac linethickness="0pt">
+        <mfrac linethickness="0">
             <mi>n</mi>
             <mi>k</mi>
         </mfrac>

--- a/latex2mmlc/tests/snapshots/wiki_test__wiki121.snap
+++ b/latex2mmlc/tests/snapshots/wiki_test__wiki121.snap
@@ -5,7 +5,7 @@ expression: "\\dbinom{n}{k}"
 <math>
     <mrow>
         <mo>(</mo>
-        <mfrac linethickness="0pt" displaystyle="true">
+        <mfrac linethickness="0" displaystyle="true">
             <mi>n</mi>
             <mi>k</mi>
         </mfrac>

--- a/latex2mmlc_wasm/tests/wasm.rs
+++ b/latex2mmlc_wasm/tests/wasm.rs
@@ -7,7 +7,7 @@ use latex2mmlc::token::{TokLoc, Token};
 #[wasm_bindgen_test]
 fn check_sizes() {
     assert_eq!(std::mem::size_of::<Token>(), 12, "size of Token");
-    assert_eq!(std::mem::size_of::<TokLoc>(), 16, "size of TokLoc");
+    assert_eq!(std::mem::size_of::<TokLoc>(), 20, "size of TokLoc");
     assert_eq!(std::mem::size_of::<Node>(), 16, "size of Node");
     assert_eq!(std::mem::size_of::<NodeList>(), 4, "size of Node");
 }

--- a/latex2mmlc_wasm/tests/wasm.rs
+++ b/latex2mmlc_wasm/tests/wasm.rs
@@ -7,7 +7,7 @@ use latex2mmlc::token::{TokLoc, Token};
 #[wasm_bindgen_test]
 fn check_sizes() {
     assert_eq!(std::mem::size_of::<Token>(), 12, "size of Token");
-    assert_eq!(std::mem::size_of::<TokLoc>(), 20, "size of TokLoc");
+    assert_eq!(std::mem::size_of::<TokLoc>(), 16, "size of TokLoc");
     assert_eq!(std::mem::size_of::<Node>(), 16, "size of Node");
     assert_eq!(std::mem::size_of::<NodeList>(), 4, "size of Node");
 }

--- a/mathml_renderer/src/length.rs
+++ b/mathml_renderer/src/length.rs
@@ -1,0 +1,204 @@
+//! A length, stored in $\frac{1}{360}$ of an imperial point.
+//!
+//! This is also equal to $\frac{1}{480}$ of a CSS pixel, as demonstrated by
+//! the following dimensional analysis and [CSS Values and Units 4]:
+//!
+//! $$`
+//! 1 len \times \frac{360 point}{1 nip} \times \frac{1 inch}{72 point}
+//! \times \frac{96 pixel}{1 inch} = 480 pixel
+//! `$$
+//!
+//! [CSS values and units 4]:
+//!     https://www.w3.org/TR/css-values-4/#absolute-lengths
+
+use std::error::Error;
+use std::fmt::{self, Debug, Display, Formatter};
+use std::str::FromStr;
+
+#[cfg(feature = "serde")]
+use serde::Serialize;
+
+const PT_IN_LEN: i32 = 360;
+const PX_IN_LEN: i32 = 480;
+
+/// An absolute length.
+/// See [the module][crate::length] for more information.
+#[derive(Clone, Copy)]
+#[cfg_attr(feature = "serde", derive(Serialize))]
+#[cfg_attr(feature = "serde", serde(transparent))]
+pub struct Length(pub i32);
+
+impl Length {
+    pub fn from_pt(pt: i32) -> Length {
+        Length(pt * PT_IN_LEN)
+    }
+    pub fn from_twip(twip: i32) -> Length {
+        Length(twip * (PT_IN_LEN / 10) / 2)
+    }
+    pub fn from_px(px: i32) -> Length {
+        Length(px * PX_IN_LEN)
+    }
+
+    fn write_impl(self, f: &mut Formatter<'_>, conv: i32, unit: &str) -> fmt::Result {
+        write!(f, "{}", self.0 / conv)?;
+        let frac = self.0 % conv;
+        if frac != 0 {
+            // only write two decimal points
+            write!(f, ".{}", (frac * 10) / conv)?;
+            let frac = (frac * 10) % conv;
+            if frac != 0 {
+                write!(f, "{}", (frac * 10) / conv)?;
+            }
+        }
+        write!(f, "{unit}")
+    }
+
+    pub fn display_px(self) -> impl fmt::Display {
+        struct Wrap(Length);
+        impl Display for Wrap {
+            fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+                self.0.write_impl(f, PX_IN_LEN, "px")
+            }
+        }
+        Wrap(self)
+    }
+
+    pub fn display_pt(self) -> impl fmt::Display {
+        struct Wrap(Length);
+        impl Display for Wrap {
+            fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+                self.0.write_impl(f, PT_IN_LEN, "pt")
+            }
+        }
+        Wrap(self)
+    }
+}
+
+impl FromStr for Length {
+    type Err = LengthParseError;
+    fn from_str(s: &str) -> Result<Length, LengthParseError> {
+        let conv = if s.ends_with("pt") {
+            PT_IN_LEN
+        } else if s.ends_with("px") {
+            PX_IN_LEN
+        } else {
+            return Err(LengthParseError);
+        };
+        let mut digits = s[..s.len() - 2].bytes();
+        let mut acc = 0;
+        let mut div = 1;
+        for digit in &mut digits {
+            if digit == b'.' {
+                break;
+            }
+            if digit < b'0' || digit > b'9' {
+                return Err(LengthParseError);
+            }
+            acc *= 10;
+            acc += i32::from(digit - b'0');
+        }
+        for digit in &mut digits {
+            if digit < b'0' || digit > b'9' {
+                return Err(LengthParseError);
+            }
+            acc *= 10;
+            acc += i32::from(digit - b'0');
+            div *= 10;
+        }
+        Ok(Length(acc * conv / div))
+    }
+}
+
+impl Display for Length {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        if self.0 == 0 {
+            write!(f, "0")
+        } else {
+            let (conv, unit) = if self.0 % (PT_IN_LEN / 10) == 0 || self.0 % (PX_IN_LEN / 10) != 0 {
+                // If this measure can be serialized in 10ths of a point,
+                // do that.
+                (PT_IN_LEN, "pt")
+            } else {
+                (PX_IN_LEN, "px")
+            };
+            self.write_impl(f, conv, unit)
+        }
+    }
+}
+impl Debug for Length {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "Length({self})")
+    }
+}
+
+/// A failed conversion from decimal to `Length`.
+pub struct LengthParseError;
+
+impl Error for LengthParseError {}
+impl Display for LengthParseError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.write_str("Length parse error")
+    }
+}
+impl Debug for LengthParseError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.write_str("LengthParseError")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn round_trip_pt_default() {
+        fn rt(s: &str) {
+            assert_eq!(s, &Length::from_str(s).expect("valid").to_string());
+        }
+        for i in 1..10 {
+            rt(&format!("{i}pt"));
+            rt(&format!("0.{i}pt"));
+            rt(&format!("{i}.25pt"));
+            rt(&format!("{i}.75pt"));
+            for j in 1..10 {
+                rt(&format!("{i}{j}pt"));
+                rt(&format!("{i}.{j}pt"));
+            }
+        }
+    }
+
+    #[test]
+    fn round_trip_px() {
+        fn rt(s: &str) {
+            assert_eq!(s, &Length::from_str(s).expect("valid").display_px().to_string());
+        }
+        for i in 1..10 {
+            rt(&format!("{i}px"));
+            rt(&format!("0.{i}px"));
+            rt(&format!("{i}.25px"));
+            rt(&format!("{i}.75px"));
+            for j in 1..10 {
+                rt(&format!("{i}{j}px"));
+                rt(&format!("{i}.{j}px"));
+            }
+        }
+    }
+
+    #[test]
+    fn round_trip_pt() {
+        fn rt(s: &str) {
+            assert_eq!(s, &Length::from_str(s).expect("valid").display_pt().to_string());
+        }
+        for i in 1..10 {
+            rt(&format!("{i}pt"));
+            rt(&format!("0.{i}pt"));
+            rt(&format!("{i}.25pt"));
+            rt(&format!("{i}.75pt"));
+            for j in 1..10 {
+                rt(&format!("{i}{j}pt"));
+                rt(&format!("{i}.{j}pt"));
+            }
+        }
+    }
+}
+

--- a/mathml_renderer/src/length.rs
+++ b/mathml_renderer/src/length.rs
@@ -40,17 +40,18 @@ impl Length {
     }
 
     fn write_impl(self, f: &mut Formatter<'_>, conv: i32, unit: &str) -> fmt::Result {
-        write!(f, "{}", self.0 / conv)?;
+        <i32 as Display>::fmt(&(self.0 / conv), f)?;
         let frac = self.0 % conv;
         if frac != 0 {
             // only write two decimal points
-            write!(f, ".{}", (frac * 10) / conv)?;
+            f.write_str(".")?;
+            <i32 as Display>::fmt(&(frac * 10 / conv), f)?;
             let frac = (frac * 10) % conv;
             if frac != 0 {
-                write!(f, "{}", (frac * 10) / conv)?;
+                <i32 as Display>::fmt(&(frac * 10 / conv), f)?;
             }
         }
-        write!(f, "{unit}")
+        f.write_str(unit)
     }
 
     pub fn display_px(self) -> impl fmt::Display {
@@ -112,7 +113,7 @@ impl FromStr for Length {
 impl Display for Length {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         if self.0 == 0 {
-            write!(f, "0")
+            f.write_str("0")
         } else {
             let (conv, unit) = if self.0 % (PT_IN_LEN / 10) == 0 || self.0 % (PX_IN_LEN / 10) != 0 {
                 // If this measure can be serialized in 10ths of a point,
@@ -127,7 +128,9 @@ impl Display for Length {
 }
 impl Debug for Length {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(f, "Length({self})")
+        f.write_str("Length(")?;
+        <Self as Display>::fmt(self, f)?;
+        f.write_str(")")
     }
 }
 

--- a/mathml_renderer/src/lib.rs
+++ b/mathml_renderer/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod arena;
 pub mod ast;
 pub mod attribute;
+pub mod length;
 pub mod ops;


### PR DESCRIPTION
This commit includes a general typed Length that we can use for most spots where this needs tracked.