### PR TITLE
Rewrite `Length::from_str` without the implicit bounds check

### DIFF
--- a/latex2mmlc/src/parse.rs
+++ b/latex2mmlc/src/parse.rs
@@ -7,7 +7,7 @@ use mathml_renderer::{
     attribute::{
         Align, FracAttr, MathSpacing, MathVariant, OpAttr, StretchMode, Style, TextTransform,
     },
-    length::{Length, LengthParseError},
+    length::Length,
     ops,
 };
 
@@ -283,9 +283,10 @@ where
                 let (loc, length) = self.parse_text_group()?;
                 let lt = match length.trim() {
                     "" => None,
-                    decimal => Some(Length::from_str(decimal).map_err(|LengthParseError| {
-                        LatexError(loc, LatexErrKind::ExpectedLength(decimal))
-                    })?),
+                    decimal => Some(
+                        Length::from_str(decimal)
+                            .map_err(|_| LatexError(loc, LatexErrKind::ExpectedLength(decimal)))?,
+                    ),
                 };
                 let style = match self.parse_next(true)? {
                     Node::Number(num) => match num.as_bytes() {

--- a/latex2mmlc/src/snapshots/latex2mmlc__parse__tests__genfrac.snap
+++ b/latex2mmlc/src/snapshots/latex2mmlc__parse__tests__genfrac.snap
@@ -10,7 +10,7 @@ expression: "\\genfrac(){1pt}{0}{1}{2}"
     content: Frac(
       num: Number("1"),
       den: Number("2"),
-      lt: Some(-2147483288),
+      lt: Some(360),
       attr: None,
     ),
   ),


### PR DESCRIPTION
closes #380 

Turns out it was the implicit bounds check in

```rust
let mut digits = s[..s.len() - 2].bytes();
```
which made the WASM code be so huge.