### PR TITLE
Make `\tilde` work on Safari with a workaround

### DIFF
--- a/math-core/src/latex_parser/commands.rs
+++ b/math-core/src/latex_parser/commands.rs
@@ -590,7 +590,7 @@ static COMMANDS: phf::Map<&'static str, Token> = phf::phf_map! {
     "th" => Letter(symbol::LATIN_SMALL_LETTER_THORN),
     "therefore" => Relation(symbol::THEREFORE),
     "theta" => Letter(symbol::GREEK_SMALL_LETTER_THETA),
-    "tilde" => OverUnder(symbol::COMBINING_TILDE, true, Some(OpAttr::StretchyFalse)),
+    "tilde" => OverUnder(symbol::COMBINING_TILDE, true, Some(OpAttr::StretchyTrue)), // should be stretchy=false, but Safari has a bug
     "times" => BinaryOp(symbol::MULTIPLICATION_SIGN),
     "to" => Relation(symbol::RIGHTWARDS_ARROW),
     "top" => Letter(symbol::DOWN_TACK),

--- a/math-core/tests/snapshots/wiki_test__wiki007.snap
+++ b/math-core/tests/snapshots/wiki_test__wiki007.snap
@@ -15,7 +15,7 @@ expression: "\\check{a}, \\breve{a}, \\tilde{a}, \\bar{a}"
     <mo>,</mo>
     <mover accent="true">
         <mi>a</mi>
-        <mo stretchy="false">̃</mo>
+        <mo stretchy="true">̃</mo>
     </mover>
     <mo>,</mo>
     <mover accent="true">


### PR DESCRIPTION
ref #520 