### PR TITLE
Use the `EndToken` enum for `parse_sequence`

### DIFF
--- a/crates/math-core/src/error.rs
+++ b/crates/math-core/src/error.rs
@@ -7,7 +7,7 @@ use strum_macros::IntoStaticStr;
 use crate::MathDisplay;
 use crate::environments::Env;
 use crate::html_utils::{escape_double_quoted_html_attribute, escape_html_content};
-use crate::token::Token;
+use crate::token::{EndToken, Token};
 
 /// Represents an error that occurred during LaTeX parsing or rendering.
 #[derive(Debug, Clone)]
@@ -49,18 +49,6 @@ pub enum LatexErrKind<'config> {
     MacroParameterOutsideCustomCommand,
     HardLimitExceeded,
     Internal,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, IntoStaticStr)]
-pub enum EndToken {
-    #[strum(serialize = r"\end{...}")]
-    End,
-    #[strum(serialize = r"}")]
-    GroupClose,
-    #[strum(serialize = r"\right")]
-    Right,
-    #[strum(serialize = r"]")]
-    SquareBracketClose,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, IntoStaticStr)]

--- a/crates/math-core/src/lexer.rs
+++ b/crates/math-core/src/lexer.rs
@@ -7,8 +7,8 @@ use mathml_renderer::symbol::{self, MathMLOperator};
 use crate::CustomCmds;
 use crate::commands::{get_command, get_text_command};
 use crate::environments::Env;
-use crate::error::{EndToken, GetUnwrap, LatexErrKind, LatexError};
-use crate::token::{TokLoc, Token};
+use crate::error::{GetUnwrap, LatexErrKind, LatexError};
+use crate::token::{EndToken, TokLoc, Token};
 
 /// Lexer
 pub(crate) struct Lexer<'config, 'source> {

--- a/crates/math-core/src/text_parser.rs
+++ b/crates/math-core/src/text_parser.rs
@@ -6,10 +6,10 @@ use mathml_renderer::{
 };
 
 use crate::{
-    error::{EndToken, LatexErrKind, LatexError},
+    error::{LatexErrKind, LatexError},
     parser::{ParseResult, Parser},
     specifications::LatexUnit,
-    token::{TokLoc, Token},
+    token::{EndToken, TokLoc, Token},
 };
 
 impl<'cell, 'arena, 'source, 'config> Parser<'cell, 'arena, 'source, 'config> {

--- a/crates/math-core/src/token_manager.rs
+++ b/crates/math-core/src/token_manager.rs
@@ -1,9 +1,9 @@
 use std::collections::VecDeque;
 
 use crate::{
-    error::{EndToken, LatexErrKind, LatexError},
+    error::{LatexErrKind, LatexError},
     lexer::Lexer,
-    token::{TokLoc, Token},
+    token::{EndToken, TokLoc, Token},
 };
 
 pub(super) struct TokenManager<'source, 'config> {


### PR DESCRIPTION
This is in preparation for merging `Token::Begin` and `Token::End` with `Token::EnvName` because it was a bit weird to use `Token::Begin` and `Token::End` with an associated `Env` as the stopping token for `parse_sequence` when `parse_sequence` doesn't actually look at the `Env`.

Also, this change makes error reporting slightly less awkward.