### PR TITLE
Fix two spacing problems

### DIFF
--- a/crates/math-core/src/parser.rs
+++ b/crates/math-core/src/parser.rs
@@ -330,7 +330,7 @@ where
                 })
             }
             Token::Ord(ord) => {
-                let attr = if matches!(ord.cat, OrdCategory::FG | OrdCategory::FGandForceDefault) {
+                let attr = if matches!(ord.cat, OrdCategory::FGandForceDefault) {
                     // Category F+G operators will stretch in pre- and postfix positions,
                     // so we explicitly set the stretchy attribute to false to prevent that.
                     // Alternatively, we could set `form="infix"` on them.
@@ -576,7 +576,9 @@ where
                 }
             }
             Token::Overset | Token::Underset => {
+                let old_script_style = mem::replace(&mut self.state.script_style, true);
                 let symbol = self.parse_next(ParseAs::Arg)?;
+                self.state.script_style = old_script_style;
                 let token = self.next_token();
                 let old_boundary_hack = mem::replace(&mut self.state.right_boundary_hack, true);
                 let (cls, target) =

--- a/crates/math-core/tests/conversion_test.rs
+++ b/crates/math-core/tests/conversion_test.rs
@@ -334,6 +334,8 @@ fn main() {
         ("idotsint_with_limits", r"\idotsint\limits_0^1 xy"),
         ("cdots_before_open", r"4 + \cdots ()"),
         ("cdots_before_close", r"{\sum \cdots}"),
+        ("infix_double_bar", r"x \| y"),
+        ("underset_tilde", r"\underset{z\sim Z}{\mathbb{E}}"),
     ];
 
     let config = MathCoreConfig {

--- a/crates/math-core/tests/snapshots/conversion_test__infix_double_bar.snap
+++ b/crates/math-core/tests/snapshots/conversion_test__infix_double_bar.snap
@@ -1,0 +1,9 @@
+---
+source: crates/math-core/tests/conversion_test.rs
+expression: "x \\| y"
+---
+<math>
+    <mi>x</mi>
+    <mo stretchy="false" lspace="0" rspace="0">‖</mo>
+    <mi>y</mi>
+</math>

--- a/crates/math-core/tests/snapshots/conversion_test__underset_tilde.snap
+++ b/crates/math-core/tests/snapshots/conversion_test__underset_tilde.snap
@@ -1,0 +1,14 @@
+---
+source: crates/math-core/tests/conversion_test.rs
+expression: "\\underset{z\\sim Z}{\\mathbb{E}}"
+---
+<math>
+    <munder>
+        <mi>𝔼</mi>
+        <mrow>
+            <mi>z</mi>
+            <mo lspace="0" rspace="0">∼</mo>
+            <mi>Z</mi>
+        </mrow>
+    </munder>
+</math>

--- a/crates/math-core/tests/snapshots/wiki_test__wiki020.snap
+++ b/crates/math-core/tests/snapshots/wiki_test__wiki020.snap
@@ -9,9 +9,9 @@ expression: "\\Pr j, \\hom l, \\lVert z \\rVert, \\arg z"
     <mo lspace="0" rspace="0.1667em">hom</mo>
     <mi>l</mi>
     <mo>,</mo>
-    <mo stretchy="false">‖</mo>
+    <mo stretchy="false" lspace="0" rspace="0">‖</mo>
     <mi>z</mi>
-    <mo stretchy="false">‖</mo>
+    <mo stretchy="false" lspace="0" rspace="0">‖</mo>
     <mo>,</mo>
     <mo lspace="0" rspace="0.1667em">arg</mo>
     <mi>z</mi>

--- a/crates/math-core/tests/snapshots/wiki_test__wiki147.snap
+++ b/crates/math-core/tests/snapshots/wiki_test__wiki147.snap
@@ -3,11 +3,11 @@ source: crates/math-core/tests/wiki_test.rs
 expression: "\\| \\big\\| \\Big\\| \\bigg\\| \\Bigg\\| \\dots \\Bigg| \\bigg| \\Big| \\big| |"
 ---
 <math>
-    <mo stretchy="false">‖</mo>
-    <mo maxsize="1.2em" minsize="1.2em" symmetric="true">‖</mo>
-    <mo maxsize="1.623em" minsize="1.623em" symmetric="true">‖</mo>
-    <mo maxsize="2.047em" minsize="2.047em" symmetric="true">‖</mo>
-    <mo maxsize="2.470em" minsize="2.470em" symmetric="true">‖</mo>
+    <mo stretchy="false" lspace="0" rspace="0">‖</mo>
+    <mo maxsize="1.2em" minsize="1.2em" stretchy="true" symmetric="true" lspace="0" rspace="0">‖</mo>
+    <mo maxsize="1.623em" minsize="1.623em" stretchy="true" symmetric="true" lspace="0" rspace="0">‖</mo>
+    <mo maxsize="2.047em" minsize="2.047em" stretchy="true" symmetric="true" lspace="0" rspace="0">‖</mo>
+    <mo maxsize="2.470em" minsize="2.470em" stretchy="true" symmetric="true" lspace="0" rspace="0">‖</mo>
     <mo>.</mo>
     <mo lspace="0">.</mo>
     <mo lspace="0">.</mo>

--- a/crates/mathml-renderer/src/symbol.rs
+++ b/crates/mathml-renderer/src/symbol.rs
@@ -93,7 +93,7 @@ macro_rules! make_character_class {
 pub enum OrdCategory {
     /// Category F and G: Prefix or postfix, zero spacing, stretchy, symmetric
     /// (e.g. `‖`).
-    FG,
+    // FG,
     /// Category F and G: Prefix or postfix, zero spacing, stretchy, symmetric
     /// but also with an infix form with relation spacing (e.g. `|`).
     FGandForceDefault,
@@ -118,12 +118,7 @@ impl OrdLike {
     #[inline(always)]
     pub const fn as_stretchable_op(&self) -> Option<StretchableOp> {
         let (stretchy, nonzero_spacing) = match self.cat {
-            OrdCategory::FG => (
-                // In theory, this should be `Stretchy::Always`, but Firefox somehow needs the
-                // extra hint that it should be symmetric to render it correctly.
-                Stretchy::AlwaysAsymmetric,
-                false,
-            ),
+            // OrdCategory::FG => (Stretchy::Always, false),
             OrdCategory::FGandForceDefault => (Stretchy::PrePostfix, true),
             OrdCategory::OnlyB => (Stretchy::Never, true),
             OrdCategory::OnlyK => (Stretchy::Never, false),
@@ -449,7 +444,7 @@ pub const GREEK_REVERSED_LUNATE_EPSILON_SYMBOL: char = '϶';
 //
 // Unicode Block: General Punctuation
 //
-pub const DOUBLE_VERTICAL_LINE: OrdLike = ord('‖', OrdCategory::FG);
+pub const DOUBLE_VERTICAL_LINE: OrdLike = ord('‖', OrdCategory::FGandForceDefault); // should actually be FG
 
 pub const DAGGER: char = '†';
 pub const DOUBLE_DAGGER: char = '‡';


### PR DESCRIPTION
- `x \| y` rendered incorrectly on Firefox
- `\underset{z\sim Z}{\mathbb{E}}` didn't have scriptstyle spacing set