### PR TITLE
chore: release v0.6.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -358,7 +358,7 @@ dependencies = [
 
 [[package]]
 name = "math-core"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "ariadne",
  "insta",
@@ -378,7 +378,7 @@ dependencies = [
 
 [[package]]
 name = "math-core-cli"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "ariadne",
  "clap",
@@ -391,7 +391,7 @@ dependencies = [
 
 [[package]]
 name = "math-core-python"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "ariadne",
  "math-core",
@@ -401,7 +401,7 @@ dependencies = [
 
 [[package]]
 name = "math-core-renderer-internal"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "bitflags",
  "dtoa",
@@ -414,7 +414,7 @@ dependencies = [
 
 [[package]]
 name = "math-core-wasm"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "ariadne",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ resolver = "2"
 edition = "2024"
 rust-version = "1.91"
 license = "MIT"
-version = "0.6.1"
+version = "0.6.2"
 repository = "https://github.com/tmke8/math-core"
 
 [workspace.dependencies]

--- a/crates/math-core-cli/Cargo.toml
+++ b/crates/math-core-cli/Cargo.toml
@@ -17,7 +17,7 @@ path = "src/main.rs"
 
 [dependencies]
 clap = { version = "4.6.1", features = ["derive"] }
-math-core = { path = "../math-core", features = ["serde", "ariadne"], version = "0.6.1" }
+math-core = { path = "../math-core", features = ["serde", "ariadne"], version = "0.6.2" }
 ariadne = { workspace = true }
 memchr = { workspace = true }
 phf = { version = "0.13.1", features = ["macros"] }

--- a/crates/math-core/Cargo.toml
+++ b/crates/math-core/Cargo.toml
@@ -19,7 +19,7 @@ categories = ["science"]
 exclude = ["/src/snapshots", "/tests/snapshots"]
 
 [dependencies]
-mathml-renderer = { path = "../mathml-renderer", package = "math-core-renderer-internal", version = "0.6.1" }
+mathml-renderer = { path = "../mathml-renderer", package = "math-core-renderer-internal", version = "0.6.2" }
 serde = { workspace = true, optional = true }
 serde-tuple-vec-map = { version = "1.0.1", optional = true }
 phf = { version = "0.13.1", features = ["macros"] }
@@ -32,7 +32,7 @@ ariadne = { workspace = true, optional = true }
 
 [dev-dependencies]
 math-core = { path = ".", features = ["serde", "ariadne"] }
-mathml-renderer = { path = "../mathml-renderer", package = "math-core-renderer-internal", version = "0.6.1", features = ["serde"] }
+mathml-renderer = { path = "../mathml-renderer", package = "math-core-renderer-internal", version = "0.6.2", features = ["serde"] }
 insta = { version = "1.47.2", features = ["default", "ron"] }
 regex = "1.12.3"
 minijinja = "2.20.0"

--- a/nodejs/package-lock.json
+++ b/nodejs/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "math-core",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "math-core",
-      "version": "0.6.1",
+      "version": "0.6.2",
       "license": "MIT",
       "devDependencies": {
         "@types/chai": "^5.2.2",

--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "math-core",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Convert LaTeX to MathML Core",
   "homepage": "https://github.com/tmke8/math-core#readme",
   "bugs": {


### PR DESCRIPTION



## 🤖 New release

* `math-core-renderer-internal`: 0.6.1 -> 0.6.2
* `math-core`: 0.6.1 -> 0.6.2 (✓ API compatible changes)
* `math-core-cli`: 0.6.1 -> 0.6.2

<details><summary><i><b>Changelog</b></i></summary><p>





</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).