### PR TITLE
Make `\label` work on the last row of numbered envs

### DIFF
--- a/crates/math-core/src/environments.rs
+++ b/crates/math-core/src/environments.rs
@@ -5,7 +5,7 @@ use mathml_renderer::{
     ast::Node,
     attribute::Style,
     symbol,
-    table::{Alignment, ArraySpec},
+    table::{Alignment, ArraySpec, RowLabelInfo},
 };
 
 use crate::character_class::{StretchableOp, fenced};
@@ -129,13 +129,13 @@ impl Env {
         content: &'arena [&'arena Node<'arena>],
         array_spec: Option<&'arena ArraySpec<'arena>>,
         arena: &'arena Arena,
-        last_equation_num: Option<NonZeroU16>,
+        last_row_info: Option<&'arena RowLabelInfo<'arena>>,
         num_rows: Option<NonZeroU16>,
     ) -> Node<'arena> {
         match self {
             Env::Align | Env::AlignStar => Node::EquationArray {
                 align: Alignment::Alternating,
-                last_tag: last_equation_num,
+                last_row_info,
                 content,
             },
             Env::Aligned => Node::Table {
@@ -146,7 +146,7 @@ impl Env {
             Env::Equation | Env::EquationStar | Env::Gather | Env::GatherStar => {
                 Node::EquationArray {
                     align: Alignment::Centered,
-                    last_tag: last_equation_num,
+                    last_row_info,
                     content,
                 }
             }
@@ -165,7 +165,7 @@ impl Env {
                 Node::MultLine {
                     content,
                     num_rows: num_rows.unwrap_or(NonZeroU16::new(1).unwrap()),
-                    last_equation_num,
+                    last_row_info,
                 }
             }
             Env::Cases => {

--- a/crates/math-core/src/parser.rs
+++ b/crates/math-core/src/parser.rs
@@ -6,6 +6,7 @@ use mathml_renderer::{
     attribute::{FracAttr, LetterAttr, MathSpacing, OpAttrs, RowAttr, Style, TextTransform},
     length::Length,
     symbol::{self, OpCategory, OrdCategory, RelCategory},
+    table::RowLabelInfo,
 };
 use rustc_hash::FxHashMap;
 
@@ -1321,9 +1322,25 @@ where
                     ));
                 }
 
-                let (last_equation_num, num_rows) = if let Some(mut n) = numbered_state {
+                let (last_row_info, num_rows) = if let Some(mut n) = numbered_state {
                     match n.next_equation_number(self.equation_counter, true) {
-                        Ok(num) => (num, n.num_rows),
+                        Ok(num) => {
+                            let link_target = n.label.take();
+                            if let Some(label) = link_target
+                                && let Some(tag) = num
+                            {
+                                self.label_map.insert(label.into(), tag);
+                            }
+                            let info = if num.is_some() || link_target.is_some() {
+                                Some(self.arena.alloc_row_label_info(RowLabelInfo {
+                                    tag: num,
+                                    link_target,
+                                }))
+                            } else {
+                                None
+                            };
+                            (info, n.num_rows)
+                        }
                         Err(()) => {
                             break 'begin_env Err(LatexError(
                                 span.into(),
@@ -1336,15 +1353,7 @@ where
                 };
                 class = Class::Close;
 
-                Ok(
-                    env.construct_node(
-                        content,
-                        array_spec,
-                        self.arena,
-                        last_equation_num,
-                        num_rows,
-                    ),
-                )
+                Ok(env.construct_node(content, array_spec, self.arena, last_row_info, num_rows))
             }
             Token::OperatorName { with_limits } => {
                 let snippets = self.extract_text(None, false)?;

--- a/crates/math-core/tests/conversion_test.rs
+++ b/crates/math-core/tests/conversion_test.rs
@@ -169,6 +169,22 @@ fn main() {
             "eqref",
             r#"\begin{align} 1\label{eq:1}\\\eqref{eq:1}\end{align}"#,
         ),
+        (
+            "label_on_last_row",
+            r#"\begin{align} 1\label{eq:1}\\2\label{eq:2}\end{align}"#,
+        ),
+        (
+            "label_on_only_equation_row",
+            r#"\begin{equation} x\label{eq:1}\end{equation}"#,
+        ),
+        (
+            "eqref_to_last_row_label",
+            r#"\begin{align} 1\label{a}\\2\label{b}\end{align}\eqref{b}"#,
+        ),
+        (
+            "label_on_multline_last_row",
+            r#"\begin{multline} a\\b\\c\label{eq:m}\end{multline}"#,
+        ),
         ("align_star", r#"\begin{align*}x&=1\\y=2\end{align*}"#),
         ("equation", r#"\begin{equation}x\\=1\end{equation}"#),
         ("equation_star", r#"\begin{equation*}x\\=1\end{equation*}"#),

--- a/crates/math-core/tests/snapshots/conversion_test__eqref_to_last_row_label.snap
+++ b/crates/math-core/tests/snapshots/conversion_test__eqref_to_last_row_label.snap
@@ -1,0 +1,27 @@
+---
+source: crates/math-core/tests/conversion_test.rs
+expression: "\\begin{align} 1\\label{a}\\\\2\\label{b}\\end{align}\\eqref{b}"
+---
+<math>
+    <mtable displaystyle="true" scriptlevel="0" style="width: 100%">
+        <mtr>
+            <mtd style="width: 50%"></mtd>
+            <mtd style="text-align: right;justify-items: end;padding-right: 0;">
+                <mn>1</mn>
+            </mtd>
+            <mtd style="width: 50%;text-align: right;justify-items: end;" id="a">
+                <mtext>(1)</mtext>
+            </mtd>
+        </mtr>
+        <mtr>
+            <mtd style="width: 50%"></mtd>
+            <mtd style="text-align: right;justify-items: end;padding-right: 0;">
+                <mn>2</mn>
+            </mtd>
+            <mtd style="width: 50%;text-align: right;justify-items: end;" id="b">
+                <mtext>(2)</mtext>
+            </mtd>
+        </mtr>
+    </mtable>
+    <mtext><a href="#b">(2)</a></mtext>
+</math>

--- a/crates/math-core/tests/snapshots/conversion_test__label_on_last_row.snap
+++ b/crates/math-core/tests/snapshots/conversion_test__label_on_last_row.snap
@@ -1,0 +1,26 @@
+---
+source: crates/math-core/tests/conversion_test.rs
+expression: "\\begin{align} 1\\label{eq:1}\\\\2\\label{eq:2}\\end{align}"
+---
+<math>
+    <mtable displaystyle="true" scriptlevel="0" style="width: 100%">
+        <mtr>
+            <mtd style="width: 50%"></mtd>
+            <mtd style="text-align: right;justify-items: end;padding-right: 0;">
+                <mn>1</mn>
+            </mtd>
+            <mtd style="width: 50%;text-align: right;justify-items: end;" id="eq:1">
+                <mtext>(1)</mtext>
+            </mtd>
+        </mtr>
+        <mtr>
+            <mtd style="width: 50%"></mtd>
+            <mtd style="text-align: right;justify-items: end;padding-right: 0;">
+                <mn>2</mn>
+            </mtd>
+            <mtd style="width: 50%;text-align: right;justify-items: end;" id="eq:2">
+                <mtext>(2)</mtext>
+            </mtd>
+        </mtr>
+    </mtable>
+</math>

--- a/crates/math-core/tests/snapshots/conversion_test__label_on_multline_last_row.snap
+++ b/crates/math-core/tests/snapshots/conversion_test__label_on_multline_last_row.snap
@@ -1,0 +1,31 @@
+---
+source: crates/math-core/tests/conversion_test.rs
+expression: "\\begin{multline} a\\\\b\\\\c\\label{eq:m}\\end{multline}"
+---
+<math>
+    <mtable displaystyle="true" scriptlevel="0" style="width: 100%">
+        <mtr>
+            <mtd style="width: 7.5%"></mtd>
+            <mtd style="text-align: left;justify-items: start;">
+                <mi>a</mi>
+            </mtd>
+            <mtd style="width: 7.5%"></mtd>
+        </mtr>
+        <mtr>
+            <mtd style="width: 7.5%"></mtd>
+            <mtd>
+                <mi>b</mi>
+            </mtd>
+            <mtd style="width: 7.5%"></mtd>
+        </mtr>
+        <mtr>
+            <mtd style="width: 7.5%"></mtd>
+            <mtd style="text-align: right;justify-items: end;">
+                <mi>c</mi>
+            </mtd>
+            <mtd style="width: 7.5%;text-align: right;justify-items: end;" id="eq:m">
+                <mtext>(1)</mtext>
+            </mtd>
+        </mtr>
+    </mtable>
+</math>

--- a/crates/math-core/tests/snapshots/conversion_test__label_on_only_equation_row.snap
+++ b/crates/math-core/tests/snapshots/conversion_test__label_on_only_equation_row.snap
@@ -1,0 +1,17 @@
+---
+source: crates/math-core/tests/conversion_test.rs
+expression: "\\begin{equation} x\\label{eq:1}\\end{equation}"
+---
+<math>
+    <mtable displaystyle="true" scriptlevel="0" style="width: 100%">
+        <mtr>
+            <mtd style="width: 50%"></mtd>
+            <mtd>
+                <mi>x</mi>
+            </mtd>
+            <mtd style="width: 50%;text-align: right;justify-items: end;" id="eq:1">
+                <mtext>(1)</mtext>
+            </mtd>
+        </mtr>
+    </mtable>
+</math>

--- a/crates/mathml-renderer/src/arena.rs
+++ b/crates/mathml-renderer/src/arena.rs
@@ -4,7 +4,7 @@ use stable_arena::DroplessArena;
 
 use crate::{
     ast::Node,
-    table::{ArraySpec, ColumnSpec},
+    table::{ArraySpec, ColumnSpec, RowLabelInfo},
 };
 
 pub struct Arena {
@@ -60,6 +60,13 @@ impl Arena {
         array_spec: ArraySpec<'arena>,
     ) -> &'arena ArraySpec<'arena> {
         self.inner.alloc(array_spec)
+    }
+
+    pub fn alloc_row_label_info<'arena>(
+        &'arena self,
+        info: RowLabelInfo<'arena>,
+    ) -> &'arena RowLabelInfo<'arena> {
+        self.inner.alloc(info)
     }
 }
 

--- a/crates/mathml-renderer/src/ast.rs
+++ b/crates/mathml-renderer/src/ast.rs
@@ -11,7 +11,7 @@ use crate::fmt::new_line_and_indent;
 use crate::itoa::append_u8_as_hex;
 use crate::length::{Length, LengthUnit, LengthValue};
 use crate::symbol::MathMLOperator;
-use crate::table::{Alignment, ArraySpec, ColumnGenerator, LineType, RIGHT_ALIGN};
+use crate::table::{Alignment, ArraySpec, ColumnGenerator, LineType, RIGHT_ALIGN, RowLabelInfo};
 
 /// AST node
 #[derive(Debug)]
@@ -107,13 +107,13 @@ pub enum Node<'arena> {
     /// `<mtable>...</mtable>` for equation arrays like the `align` environment
     EquationArray {
         align: Alignment,
-        last_tag: Option<NonZeroU16>,
+        last_row_info: Option<&'arena RowLabelInfo<'arena>>,
         content: &'arena [&'arena Node<'arena>],
     },
     /// `<mtable>...</mtable>` for the `multline` environment
     MultLine {
         num_rows: NonZeroU16,
-        last_equation_num: Option<NonZeroU16>,
+        last_row_info: Option<&'arena RowLabelInfo<'arena>>,
         content: &'arena [&'arena Node<'arena>],
     },
     /// `<mtable>...</mtable>` for arrays
@@ -430,12 +430,12 @@ impl Node<'_> {
                 )?;
             }
             node @ (Node::EquationArray {
-                last_tag: last_equation_num,
+                last_row_info,
                 content,
                 ..
             }
             | Node::MultLine {
-                last_equation_num,
+                last_row_info,
                 content,
                 ..
             }) => {
@@ -461,7 +461,7 @@ impl Node<'_> {
                     content,
                     mtd_opening,
                     Some(numbering_cols),
-                    last_equation_num.as_ref().copied(),
+                    last_row_info.as_deref(),
                 )?;
             }
             Node::Array {
@@ -627,7 +627,7 @@ fn emit_table(
     content: &[&Node<'_>],
     mut col_gen: ColumnGenerator,
     numbering_cols: Option<NumberColums>,
-    last_tag: Option<NonZeroU16>,
+    last_row_info: Option<&RowLabelInfo>,
 ) -> Result<(), std::fmt::Error> {
     let child_indent2 = if base_indent > 0 {
         child_indent.saturating_add(1)
@@ -677,12 +677,16 @@ fn emit_table(
     }
     writeln_indent!(s, child_indent2, "</mtd>");
     if let Some(numbering_cols) = numbering_cols {
+        let (last_tag, last_link_target) = match last_row_info {
+            Some(info) => (info.tag, info.link_target),
+            None => (None, None),
+        };
         write_equation_num(
             s,
             child_indent2,
             child_indent3,
             last_tag,
-            None,
+            last_link_target,
             numbering_cols,
         )?;
     }
@@ -1172,11 +1176,15 @@ mod tests {
             &Node::Number("4"),
         ];
 
+        let info_with_tag = RowLabelInfo {
+            tag: NonZeroU16::new(2),
+            link_target: None,
+        };
         assert_eq!(
             render(&Node::EquationArray {
                 content: &nodes,
                 align: Alignment::Centered,
-                last_tag: NonZeroU16::new(2),
+                last_row_info: Some(&info_with_tag),
             }),
             "<mtable displaystyle=\"true\" scriptlevel=\"0\" style=\"width: 100%\"><mtr><mtd style=\"width: 50%\"></mtd><mtd><mn>1</mn></mtd><mtd><mn>2</mn></mtd><mtd style=\"width: 50%;text-align: right;justify-items: end;\"><mtext>(1)</mtext></mtd></mtr><mtr><mtd style=\"width: 50%\"></mtd><mtd><mn>3</mn></mtd><mtd><mn>4</mn></mtd><mtd style=\"width: 50%;text-align: right;justify-items: end;\"><mtext>(2)</mtext></mtd></mtr></mtable>"
         );
@@ -1185,7 +1193,7 @@ mod tests {
             render(&Node::EquationArray {
                 content: &nodes,
                 align: Alignment::Centered,
-                last_tag: None,
+                last_row_info: None,
             }),
             "<mtable displaystyle=\"true\" scriptlevel=\"0\" style=\"width: 100%\"><mtr><mtd style=\"width: 50%\"></mtd><mtd><mn>1</mn></mtd><mtd><mn>2</mn></mtd><mtd style=\"width: 50%;text-align: right;justify-items: end;\"><mtext>(1)</mtext></mtd></mtr><mtr><mtd style=\"width: 50%\"></mtd><mtd><mn>3</mn></mtd><mtd><mn>4</mn></mtd><mtd style=\"width: 50%\"></mtd></mtr></mtable>"
         );

--- a/crates/mathml-renderer/src/table.rs
+++ b/crates/mathml-renderer/src/table.rs
@@ -43,6 +43,19 @@ pub enum Alignment {
     Alternating,
 }
 
+/// Equation-number / label metadata for the last row of a numbered environment.
+///
+/// The last row of `align`, `gather`, `equation`, `multline`, etc. has no trailing
+/// `\\` row separator, so its tag (equation number) and link target (from `\label`)
+/// can't ride on a `Node::RowSeparator`. They're arena-allocated and threaded
+/// through `Node::EquationArray` / `Node::MultLine` instead.
+#[derive(Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize))]
+pub struct RowLabelInfo<'arena> {
+    pub tag: Option<NonZeroU16>,
+    pub link_target: Option<&'arena str>,
+}
+
 enum AlignmentType<'arena> {
     Predefined(Alignment),
     Custom(&'arena ArraySpec<'arena>),


### PR DESCRIPTION
Labels on the last row of `align`, `gather`, `equation`, `multline`, etc. were previously dropped because the label was only consumed when a `\\` row separator was processed. Drain any pending label at env-end and thread its tag plus link target through a new arena-allocated `RowLabelInfo` on `EquationArray` / `MultLine`.

ref #21