### PR TITLE
Add some missing double-struck transforms

### DIFF
--- a/crates/mathml-renderer/src/attribute.rs
+++ b/crates/mathml-renderer/src/attribute.rs
@@ -330,6 +330,12 @@ impl TextTransform {
                 'N' => 'ℕ',
                 'R' => 'ℝ',
                 'Z' => 'ℤ',
+                'π' => 'ℼ',
+                'γ' => 'ℽ',
+                'Γ' => 'ℾ',
+                'Π' => 'ℿ',
+                '∑' => '⅀',
+                // FIXME: add Arabic double-struck characters
                 _ => c,
             },
             TextTransform::Italic => match c {


### PR DESCRIPTION
I left out the Arabic characters in the U+1EEA1-U+1EEBB range, because I'm not sure whether the mapping is supposed to be from the normal letter or the mathematical isolated form.