### PR TITLE
Cat wasm sizes in CI logs

### DIFF
--- a/.github/workflows/wasm_ci.yml
+++ b/.github/workflows/wasm_ci.yml
@@ -93,6 +93,10 @@ jobs:
         uses: actions/download-artifact@v7
         with:
           name: wasm-size-comment
+
+      - name: "Print WASM sizes to terminal"
+        run: "cat wasm-size-comment.md"
+
       - name: "Comment on PR with WASM sizes"
         uses: actions/github-script@v8
         id: post_comment
@@ -107,6 +111,4 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               body: comment
-            })
-      - run: echo "Posting the comment failed."
-        if: job.steps.post_comment.outcome == 'failure'
+            });


### PR DESCRIPTION
Allows this information to be viewed even when the job fails to post a comment.