### PR TITLE
Don't trim non-ASCII whitespace

### DIFF
--- a/crates/math-core/src/parser.rs
+++ b/crates/math-core/src/parser.rs
@@ -287,7 +287,7 @@ where
                 let (tag_name, literal_span) = self.parse_string_literal()?;
                 if let Some(numbered_state) = &mut self.state.numbered {
                     // For now, we only support numeric tags.
-                    if let Ok(tag_num) = tag_name.trim().parse::<u16>()
+                    if let Ok(tag_num) = tag_name.trim_ascii().parse::<u16>()
                         && tag_num != 0
                     {
                         numbered_state.custom_next_number = NonZeroU16::new(tag_num);
@@ -654,7 +654,7 @@ where
             }
             Token::CustomSpace => {
                 let (length, span) = self.parse_string_literal()?;
-                match parse_length_specification(length.trim()) {
+                match parse_length_specification(length.trim_ascii()) {
                     Some(space) => Ok(Node::Space(space)),
                     None => Err(LatexError(
                         span,
@@ -740,7 +740,7 @@ where
                 let open = get_delimiter(self)?;
                 let close = get_delimiter(self)?;
                 let (length, span) = self.parse_string_literal()?;
-                let lt = match length.trim() {
+                let lt = match length.trim_ascii() {
                     "" => Length::none(),
                     decimal => parse_length_specification(decimal).ok_or_else(|| {
                         Box::new(LatexError(

--- a/crates/math-core/src/specifications.rs
+++ b/crates/math-core/src/specifications.rs
@@ -62,7 +62,7 @@ pub(crate) fn parse_length_specification(s: &str) -> Option<Length> {
     // (This can fail if `unit_offset` is not a valid UTF-8 boundary.)
     let (digits, unit) = s.split_at_checked(unit_offset)?;
 
-    let value = crate::atof::limited_float_parse(digits.trim_end())?;
+    let value = crate::atof::limited_float_parse(digits.trim_ascii_end())?;
 
     let parsed_unit = LatexUnit::try_from(unit).ok()?;
     Some(parsed_unit.length_with_unit(value))


### PR DESCRIPTION
Not as big a size win as I hoped, but still, no reason not to do it