### PR TITLE
Force spacing of ForceOpen/Close to zero

### DIFF
--- a/crates/math-core/src/character_class.rs
+++ b/crates/math-core/src/character_class.rs
@@ -100,7 +100,7 @@ impl StretchableOp {
             }
             OrdCategory::K => (Stretchy::Never, DelimiterSpacing::Zero),
             OrdCategory::KButUsedToBeB => (Stretchy::Never, DelimiterSpacing::Other),
-            OrdCategory::D | OrdCategory::E | OrdCategory::I | OrdCategory::IK => {
+            OrdCategory::D | OrdCategory::E | OrdCategory::DE | OrdCategory::I | OrdCategory::IK => {
                 return None;
             }
         };

--- a/crates/math-core/src/character_class.rs
+++ b/crates/math-core/src/character_class.rs
@@ -100,7 +100,11 @@ impl StretchableOp {
             }
             OrdCategory::K => (Stretchy::Never, DelimiterSpacing::Zero),
             OrdCategory::KButUsedToBeB => (Stretchy::Never, DelimiterSpacing::Other),
-            OrdCategory::D | OrdCategory::E | OrdCategory::DE | OrdCategory::I | OrdCategory::IK => {
+            OrdCategory::D
+            | OrdCategory::E
+            | OrdCategory::DE
+            | OrdCategory::I
+            | OrdCategory::IK => {
                 return None;
             }
         };

--- a/crates/math-core/src/lexer.rs
+++ b/crates/math-core/src/lexer.rs
@@ -377,7 +377,7 @@ type CharSpan = (Option<char>, Range<usize>);
 
 fn nonalpha_nonspecial_ascii_to_token(ch: char) -> Option<Token<'static>> {
     let tok_ref = match ch {
-        '!' => &Token::ForceClose(symbol::EXCLAMATION_MARK, ForceStretchy::No),
+        '!' => &Token::Close(symbol::EXCLAMATION_MARK),
         '(' => &Token::Open(symbol::LEFT_PARENTHESIS),
         ')' => &Token::Close(symbol::RIGHT_PARENTHESIS),
         '*' => &const { Token::ForceBinaryOp(symbol::ASTERISK_OPERATOR.as_op()) },

--- a/crates/math-core/src/parser.rs
+++ b/crates/math-core/src/parser.rs
@@ -1098,8 +1098,8 @@ where
                 Ok(Node::Operator {
                     op,
                     attrs: OpAttrs::FORM_PREFIX,
-                    left: None,
-                    right: None,
+                    left: Some(MathSpacing::Zero),
+                    right: Some(MathSpacing::Zero),
                     size: None,
                 })
             }
@@ -1108,8 +1108,8 @@ where
                 Ok(Node::Operator {
                     op,
                     attrs: OpAttrs::FORM_POSTFIX,
-                    left: None,
-                    right: None,
+                    left: Some(MathSpacing::Zero),
+                    right: Some(MathSpacing::Zero),
                     size: None,
                 })
             }

--- a/crates/math-core/src/parser.rs
+++ b/crates/math-core/src/parser.rs
@@ -1133,7 +1133,10 @@ where
                 if open {
                     class = Class::Open;
                 }
-                let mut attrs = if matches!(paren.category(), OrdCategory::FGandForceDefault) {
+                let mut attrs = if matches!(
+                    paren.category(),
+                    OrdCategory::FGandForceDefault | OrdCategory::DE
+                ) {
                     // For this category of symbol, we have to force the form attribute
                     // in order to get correct spacing.
                     if open {

--- a/crates/math-core/tests/snapshots/wiki_test__wiki081.snap
+++ b/crates/math-core/tests/snapshots/wiki_test__wiki081.snap
@@ -3,8 +3,8 @@ source: crates/math-core/tests/wiki_test.rs
 expression: "\\ulcorner \\urcorner \\llcorner \\lrcorner"
 ---
 <math>
-    <mo form="prefix">⌜</mo>
-    <mo form="postfix">⌝</mo>
-    <mo form="prefix">⌞</mo>
-    <mo form="postfix">⌟</mo>
+    <mo form="prefix" lspace="0" rspace="0">⌜</mo>
+    <mo form="postfix" lspace="0" rspace="0">⌝</mo>
+    <mo form="prefix" lspace="0" rspace="0">⌞</mo>
+    <mo form="postfix" lspace="0" rspace="0">⌟</mo>
 </math>

--- a/crates/mathml-renderer/src/ast.rs
+++ b/crates/mathml-renderer/src/ast.rs
@@ -977,7 +977,7 @@ mod tests {
         assert_eq!(
             render(&Node::Over {
                 symbol: &Node::Operator {
-                    op: symbol::EXCLAMATION_MARK,
+                    op: symbol::EXCLAMATION_MARK.as_op(),
                     attrs: OpAttrs::empty(),
                     left: None,
                     right: None,

--- a/crates/mathml-renderer/src/symbol.rs
+++ b/crates/mathml-renderer/src/symbol.rs
@@ -139,6 +139,8 @@ pub enum OrdCategory {
     D,
     /// Category E: Postfix, zero spacing (e.g. `′`).
     E,
+    /// Category D and E: Prefix or postfix, zero spacing (e.g. ` !`)
+    DE,
     /// Category F: Prefix, zero spacing, stretchy, symmetric (e.g. `(`).
     /// Meant to be stretched vertically.
     F,
@@ -226,7 +228,7 @@ impl Punct {
 //
 // Unicode Block: Basic Latin
 //
-pub const EXCLAMATION_MARK: MathMLOperator = MathMLOperator::from_char('!');
+pub const EXCLAMATION_MARK: OrdLike = OrdLike::new('!', OrdCategory::DE);
 // pub const QUOTATION_MARK: char = '"';
 pub const NUMBER_SIGN: char = '#';
 pub const DOLLAR_SIGN: char = '$';


### PR DESCRIPTION
If a Unicode character doesn't appear in the operator dictionary, the spacing defaults to relation spacing.