### PR TITLE
Superscript prime chars entered with direct input, and add negative kerning to long runs of primes

### DIFF
--- a/crates/math-core/src/commands.rs
+++ b/crates/math-core/src/commands.rs
@@ -9,7 +9,7 @@ use mathml_renderer::{
 use crate::predefined;
 use crate::specifications::LatexUnit;
 use crate::token::{
-    ForceStretchy, InfixDelim, MathClassKind, Mode, PhantomKind, TextToken,
+    ForceStretchy, InfixDelim, MathClassKind, Mode, PhantomKind, PrimeKind, TextToken,
     Token::{self, *},
     UnitKind,
 };
@@ -1205,13 +1205,14 @@ static UNICODE_OPERATORS: phf::Map<char, Token> = phf::phf_map! {
     // …
     '¬' => Ord(symbol::NOT_SIGN),
     // …
-    '″' => Ord(symbol::DOUBLE_PRIME),
-    '‴' => Ord(symbol::TRIPLE_PRIME),
-    '‵' => Ord(symbol::REVERSED_PRIME),
-    '‶' => Ord(symbol::REVERSED_DOUBLE_PRIME),
-    '‷' => Ord(symbol::REVERSED_TRIPLE_PRIME),
+    '′' => Prime(PrimeKind::Single),
+    '″' => Prime(PrimeKind::Double),
+    '‴' => Prime(PrimeKind::Triple),
+    '‵' => Prime(PrimeKind::Reversed),
+    '‶' => Prime(PrimeKind::ReversedDouble),
+    '‷' => Prime(PrimeKind::ReversedTriple),
     // …
-    '⁗' => Ord(symbol::QUADRUPLE_PRIME),
+    '⁗' => Prime(PrimeKind::Quadruple),
     // …
     '∀' => Ord(symbol::FOR_ALL),
     '∁' => Ord(symbol::COMPLEMENT),

--- a/crates/math-core/src/lexer.rs
+++ b/crates/math-core/src/lexer.rs
@@ -8,7 +8,7 @@ use crate::CommandConfig;
 use crate::commands::{get_command, get_operator_from_unicode};
 use crate::environments::Env;
 use crate::error::{GetUnwrap, LatexErrKind, LatexError};
-use crate::token::{EndToken, Mode, Span, TokSpan, Token};
+use crate::token::{EndToken, Mode, PrimeKind, Span, TokSpan, Token};
 
 /// Lexer
 pub(crate) struct Lexer<'config, 'source>
@@ -252,7 +252,7 @@ impl<'config, 'source> Lexer<'config, 'source> {
                 }
             }
             '&' => Token::NewColumn,
-            '\'' => Token::Prime,
+            '\'' => Token::MathOrTextMode(&Token::Prime(PrimeKind::Single), '’'),
             '<' => Token::MathOrTextMode(&Token::Relation(symbol::LESS_THAN_SIGN), '<'),
             '>' => Token::MathOrTextMode(&Token::Relation(symbol::GREATER_THAN_SIGN), '>'),
             '[' => Token::SquareBracketOpen,

--- a/crates/math-core/src/parser.rs
+++ b/crates/math-core/src/parser.rs
@@ -6,7 +6,7 @@ use mathml_renderer::{
     attribute::{FracAttr, LetterAttr, MathSpacing, OpAttrs, Style},
     length::Length,
     super_char::SuperChar,
-    symbol::{self, MathMLOperator, OpCategory, OrdCategory, RelCategory},
+    symbol::{self, MathMLOperator, OpCategory, OrdCategory, OrdLike, RelCategory},
     table::RowLabelInfo,
 };
 use rustc_hash::FxHashMap;
@@ -27,8 +27,8 @@ use crate::{
     split_on_ascii::split_on_ascii,
     text_parser::TextSnippet,
     token::{
-        EndToken, InfixDelim, LimitsKind, MathClassKind, Mode, PhantomKind, Span, TokSpan, Token,
-        UnitKind,
+        EndToken, InfixDelim, LimitsKind, MathClassKind, Mode, PhantomKind, PrimeDirection,
+        PrimeKind, Span, TokSpan, Token, UnitKind,
     },
     token_queue::{MacroArgument, OneOrNone, TokenQueue},
 };
@@ -114,8 +114,8 @@ enum BoundStarterKind {
     Underscore,
     /// `^`
     Circumflex,
-    /// `'`
-    Prime,
+    /// `'` and Unicode friends
+    Prime(PrimeKind),
 }
 
 pub(super) type ParseResult<T> = Result<T, Box<LatexError>>;
@@ -674,7 +674,6 @@ where
                             | Token::ForcePunctuation(op) => op,
                             Token::SquareBracketOpen => symbol::LEFT_SQUARE_BRACKET.as_op(),
                             Token::SquareBracketClose => symbol::RIGHT_SQUARE_BRACKET.as_op(),
-                            Token::Prime => symbol::PRIME.as_op(),
                             Token::NonBreakingSpace => {
                                 MathMLOperator::from_char(symbol::NO_BREAK_SPACE)
                             }
@@ -1766,7 +1765,7 @@ where
                     },
                 })
             }
-            tok @ (Token::Underscore | Token::Circumflex | Token::Prime) => {
+            tok @ (Token::Underscore | Token::Circumflex | Token::Prime(_)) => {
                 let bounds = self
                     .get_bounds(Some((tok, span)))?
                     .ensure_no_explicit_limits()?;
@@ -2088,7 +2087,7 @@ where
     ) -> ParseResult<BoundsWithLimits<'arena>> {
         debug_assert!(matches!(
             first,
-            Some((Token::Underscore | Token::Circumflex | Token::Prime, _)) | None
+            Some((Token::Underscore | Token::Circumflex | Token::Prime(_), _)) | None
         ));
 
         let mut ret: BoundsWithLimits = BoundsWithLimits::default();
@@ -2096,9 +2095,10 @@ where
         loop {
             // retreive and consume next token
             let (next_token, next_span) = first.unwrap_or_else(|| self.tokens.peek().into_parts());
+            let next_token = next_token.unwrap_math();
             if matches!(
                 next_token,
-                Token::Underscore | Token::Circumflex | Token::Prime | Token::Limits(_)
+                Token::Underscore | Token::Circumflex | Token::Prime(_) | Token::Limits(_)
             ) && first.take().is_none()
             {
                 self.tokens.next()?;
@@ -2107,7 +2107,7 @@ where
             // parse it into a bound
             let (bound_starter_kind, bound_to_replace) = match next_token {
                 Token::Circumflex => (BoundStarterKind::Circumflex, &mut ret.bounds.1),
-                Token::Prime => (BoundStarterKind::Prime, &mut ret.bounds.1),
+                Token::Prime(kind) => (BoundStarterKind::Prime(kind), &mut ret.bounds.1),
                 Token::Underscore => (BoundStarterKind::Underscore, &mut ret.bounds.0),
                 Token::Limits(kind) => {
                     ret.limits_span = Some((kind, next_span));
@@ -2135,26 +2135,14 @@ where
     fn get_bounds_arg(
         &mut self,
     ) -> ParseResult<(BoundsWithLimits<'arena>, Vec<&'arena Node<'arena>>)> {
-        let first = *self.tokens.peek();
-        match *first.token() {
-            Token::Prime => {
+        let (first_tok, first_span) = self.tokens.peek().into_parts();
+        let first_tok = first_tok.unwrap_math();
+        match first_tok {
+            Token::Prime(prime_kind) => {
                 self.tokens.next()?;
                 Ok((
                     BoundsWithLimits {
-                        bounds: Bounds(
-                            None,
-                            Some(
-                                &const {
-                                    Node::Operator {
-                                        op: symbol::PRIME.as_op(),
-                                        attrs: OpAttrs::empty(),
-                                        left: None,
-                                        right: None,
-                                        size: None,
-                                    }
-                                },
-                            ),
-                        ),
+                        bounds: Bounds(None, Some(prime_kind.to_node())),
                         limits_span: None,
                     },
                     Vec::new(),
@@ -2176,7 +2164,7 @@ where
                 Ok((
                     BoundsWithLimits {
                         bounds: Bounds(None, None),
-                        limits_span: Some((kind, first.span())),
+                        limits_span: Some((kind, first_span)),
                     },
                     Vec::new(),
                 ))
@@ -2199,15 +2187,24 @@ where
     fn get_sub_or_sup(&mut self, mut kind: BoundStarterKind) -> ParseResult<&'arena Node<'arena>> {
         let mut nodes = Vec::with_capacity(1);
 
-        if kind == BoundStarterKind::Prime {
-            let mut prime_count = 1;
+        if let BoundStarterKind::Prime(prime_kind) = kind {
+            let mut primes: Vec<(PrimeDirection, usize)> =
+                vec![(prime_kind.direction(), prime_kind.count())];
+
             let followed_by_circumflex = loop {
                 // We use `peek_any_token` here because primes can't be separated by whitespace
                 // from each other or from a `^` that follows
-                let next_tok = self.tokens.peek_any_token();
+                let next_tok = self.tokens.peek_any_token().token().unwrap_math();
 
-                match next_tok.token() {
-                    Token::Prime => prime_count += 1,
+                match next_tok {
+                    Token::Prime(new_kind) => {
+                        let last = primes.last_mut().unwrap();
+                        if last.0 == new_kind.direction() {
+                            last.1 += new_kind.count();
+                        } else {
+                            primes.push((new_kind.direction(), new_kind.count()));
+                        }
+                    }
                     Token::Circumflex => break true,
                     _ => break false,
                 }
@@ -2215,31 +2212,40 @@ where
                 self.tokens.next_any_token()?;
             };
 
-            static PRIME_SELECTION: [symbol::OrdLike; 4] = [
-                symbol::PRIME,
-                symbol::DOUBLE_PRIME,
-                symbol::TRIPLE_PRIME,
-                symbol::QUADRUPLE_PRIME,
-            ];
+            for (direction, count) in primes {
+                let primes_arr: &[OrdLike] = match direction {
+                    PrimeDirection::Forward => &[
+                        symbol::PRIME,
+                        symbol::DOUBLE_PRIME,
+                        symbol::TRIPLE_PRIME,
+                        symbol::QUADRUPLE_PRIME,
+                    ],
+                    PrimeDirection::Reversed => &[
+                        symbol::REVERSED_PRIME,
+                        symbol::REVERSED_DOUBLE_PRIME,
+                        symbol::REVERSED_TRIPLE_PRIME,
+                    ],
+                };
 
-            // If we have between 1 and 4 primes, we can use the predefined prime operators.
-            if let Some(op) = PRIME_SELECTION.get(prime_count - 1) {
-                nodes.push(self.commit(Node::Operator {
-                    op: op.as_op(),
-                    attrs: OpAttrs::empty(),
-                    left: None,
-                    right: None,
-                    size: None,
-                }));
-            } else {
-                for _ in 0..prime_count {
+                // If we have between 1 and 4 primes, we can use the predefined prime operators.
+                if let Some(op) = primes_arr.get(count - 1) {
                     nodes.push(self.commit(Node::Operator {
-                        op: symbol::PRIME.as_op(),
+                        op: op.as_op(),
                         attrs: OpAttrs::empty(),
                         left: None,
                         right: None,
                         size: None,
                     }));
+                } else {
+                    for _ in 0..count {
+                        nodes.push(self.commit(Node::Operator {
+                            op: primes_arr[0].as_op(),
+                            attrs: OpAttrs::empty(),
+                            left: None,
+                            right: None,
+                            size: None,
+                        }));
+                    }
                 }
             }
 
@@ -2250,10 +2256,10 @@ where
             }
         }
 
-        if kind != BoundStarterKind::Prime {
+        if !matches!(kind, BoundStarterKind::Prime(_)) {
             let next = self.tokens.next()?;
             match next.token() {
-                Token::Underscore | Token::Circumflex | Token::Prime => {
+                Token::Underscore | Token::Circumflex | Token::Prime(_) => {
                     return Err(Box::new(LatexError(
                         next.span().into(),
                         LatexErrKind::BoundFollowedByBound,

--- a/crates/math-core/src/parser.rs
+++ b/crates/math-core/src/parser.rs
@@ -2237,7 +2237,21 @@ where
                         size: None,
                     }));
                 } else {
-                    for _ in 0..count {
+                    nodes.push(self.commit(Node::Operator {
+                        op: primes_arr[0].as_op(),
+                        attrs: OpAttrs::empty(),
+                        left: None,
+                        right: None,
+                        size: None,
+                    }));
+                    for _ in 1..count {
+                        nodes.push(&Node::Row {
+                            nodes: &[],
+                            attrs: RowAttrs {
+                                margin_left: Some(MathSpacing::NegativeOnePointFiveMu),
+                                ..RowAttrs::DEFAULT
+                            },
+                        });
                         nodes.push(self.commit(Node::Operator {
                             op: primes_arr[0].as_op(),
                             attrs: OpAttrs::empty(),

--- a/crates/math-core/src/snapshots/math_core__parser__tests__cancel.snap
+++ b/crates/math-core/src/snapshots/math_core__parser__tests__cancel.snap
@@ -14,6 +14,7 @@ expression: "\\cancel{abc}"
         color: None,
         style: None,
         math_shift_compact: false,
+        margin_left: None,
       ),
     ),
     notation: Notation("UP_DIAGONAL"),

--- a/crates/math-core/src/snapshots/math_core__parser__tests__displaystyle_ended_by_end.snap
+++ b/crates/math-core/src/snapshots/math_core__parser__tests__displaystyle_ended_by_end.snap
@@ -28,6 +28,7 @@ expression: "\\begin{matrix}\\sum\\displaystyle\\sum\\end{matrix}"
           color: None,
           style: Some(Display),
           math_shift_compact: false,
+          margin_left: None,
         ),
       ),
     ],

--- a/crates/math-core/src/snapshots/math_core__parser__tests__displaystyle_ended_by_right.snap
+++ b/crates/math-core/src/snapshots/math_core__parser__tests__displaystyle_ended_by_right.snap
@@ -26,6 +26,7 @@ expression: "\\left(\\displaystyle \\int\\right)\\int"
           color: None,
           style: Some(Display),
           math_shift_compact: false,
+          margin_left: None,
         ),
       ),
       Operator(
@@ -40,6 +41,7 @@ expression: "\\left(\\displaystyle \\int\\right)\\int"
       color: None,
       style: None,
       math_shift_compact: false,
+      margin_left: None,
     ),
   ),
   Operator(

--- a/crates/math-core/src/snapshots/math_core__parser__tests__genfrac.snap
+++ b/crates/math-core/src/snapshots/math_core__parser__tests__genfrac.snap
@@ -31,6 +31,7 @@ expression: "\\genfrac(){1pt}{0}{1}{2}"
       color: None,
       style: Some(Display),
       math_shift_compact: false,
+      margin_left: None,
     ),
   ),
 ]

--- a/crates/math-core/src/snapshots/math_core__parser__tests__int_bounds_relation.snap
+++ b/crates/math-core/src/snapshots/math_core__parser__tests__int_bounds_relation.snap
@@ -29,6 +29,7 @@ expression: "{\\int_0^\\infty = 4}"
       color: None,
       style: None,
       math_shift_compact: false,
+      margin_left: None,
     ),
   ),
 ]

--- a/crates/math-core/src/snapshots/math_core__parser__tests__int_relation.snap
+++ b/crates/math-core/src/snapshots/math_core__parser__tests__int_relation.snap
@@ -25,6 +25,7 @@ expression: "{\\int = 4}"
       color: None,
       style: None,
       math_shift_compact: false,
+      margin_left: None,
     ),
   ),
 ]

--- a/crates/math-core/src/snapshots/math_core__parser__tests__mathit_func.snap
+++ b/crates/math-core/src/snapshots/math_core__parser__tests__mathit_func.snap
@@ -18,6 +18,7 @@ expression: "\\mathit{ab \\log cd}"
       color: None,
       style: None,
       math_shift_compact: false,
+      margin_left: None,
     ),
   ),
 ]

--- a/crates/math-core/src/snapshots/math_core__parser__tests__mathit_mathrm_nested.snap
+++ b/crates/math-core/src/snapshots/math_core__parser__tests__mathit_mathrm_nested.snap
@@ -12,6 +12,7 @@ expression: "\\mathit{\\mathrm{a}b}"
       color: None,
       style: None,
       math_shift_compact: false,
+      margin_left: None,
     ),
   ),
 ]

--- a/crates/math-core/src/snapshots/math_core__parser__tests__mathit_of_max.snap
+++ b/crates/math-core/src/snapshots/math_core__parser__tests__mathit_of_max.snap
@@ -18,6 +18,7 @@ expression: "\\mathit{ab \\max \\alpha\\beta}"
       color: None,
       style: None,
       math_shift_compact: false,
+      margin_left: None,
     ),
   ),
 ]

--- a/crates/math-core/src/snapshots/math_core__parser__tests__mathrm_mathit_nested.snap
+++ b/crates/math-core/src/snapshots/math_core__parser__tests__mathrm_mathit_nested.snap
@@ -12,6 +12,7 @@ expression: "\\mathrm{\\mathit{a}b}"
       color: None,
       style: None,
       math_shift_compact: false,
+      margin_left: None,
     ),
   ),
 ]

--- a/crates/math-core/src/snapshots/math_core__parser__tests__mathrm_mathit_nested_multi.snap
+++ b/crates/math-core/src/snapshots/math_core__parser__tests__mathrm_mathit_nested_multi.snap
@@ -13,6 +13,7 @@ expression: "\\mathrm{ab\\mathit{cd}ef}"
       color: None,
       style: None,
       math_shift_compact: false,
+      margin_left: None,
     ),
   ),
 ]

--- a/crates/math-core/src/snapshots/math_core__parser__tests__mathrm_sqrt.snap
+++ b/crates/math-core/src/snapshots/math_core__parser__tests__mathrm_sqrt.snap
@@ -12,6 +12,7 @@ expression: "\\mathrm{\\sqrt xy}"
       color: None,
       style: None,
       math_shift_compact: false,
+      margin_left: None,
     ),
   ),
 ]

--- a/crates/math-core/src/snapshots/math_core__parser__tests__mathrm_subscript.snap
+++ b/crates/math-core/src/snapshots/math_core__parser__tests__mathrm_subscript.snap
@@ -18,6 +18,7 @@ expression: "\\mathrm{x_x y_y}"
       color: None,
       style: None,
       math_shift_compact: false,
+      margin_left: None,
     ),
   ),
 ]

--- a/crates/math-core/src/snapshots/math_core__parser__tests__matrix.snap
+++ b/crates/math-core/src/snapshots/math_core__parser__tests__matrix.snap
@@ -36,6 +36,7 @@ expression: "\\begin{pmatrix} x \\\\ y \\end{pmatrix}"
       color: None,
       style: None,
       math_shift_compact: false,
+      margin_left: None,
     ),
   ),
 ]

--- a/crates/math-core/src/snapshots/math_core__parser__tests__scriptstyle_without_braces.snap
+++ b/crates/math-core/src/snapshots/math_core__parser__tests__scriptstyle_without_braces.snap
@@ -12,6 +12,7 @@ expression: "x\\scriptstyle y"
       color: None,
       style: Some(Script),
       math_shift_compact: false,
+      margin_left: None,
     ),
   ),
 ]

--- a/crates/math-core/src/snapshots/math_core__parser__tests__sqrt_number_with_dot.snap
+++ b/crates/math-core/src/snapshots/math_core__parser__tests__sqrt_number_with_dot.snap
@@ -12,6 +12,7 @@ expression: "\\sqrt{4.}"
       color: None,
       style: None,
       math_shift_compact: false,
+      margin_left: None,
     ),
   )),
 ]

--- a/crates/math-core/src/snapshots/math_core__parser__tests__sum_relation.snap
+++ b/crates/math-core/src/snapshots/math_core__parser__tests__sum_relation.snap
@@ -25,6 +25,7 @@ expression: "{\\sum = 4}"
       color: None,
       style: None,
       math_shift_compact: false,
+      margin_left: None,
     ),
   ),
 ]

--- a/crates/math-core/src/text_parser.rs
+++ b/crates/math-core/src/text_parser.rs
@@ -106,7 +106,6 @@ impl<'arena> Parser<'_, '_, 'arena> {
                     | Token::SquareBracketOpen
                     | Token::SquareBracketClose
                     | Token::Digit(_)
-                    | Token::Prime
                     | Token::Whitespace
                     | Token::NonBreakingSpace
                     | Token::InternalStringLiteral(_)
@@ -128,7 +127,6 @@ impl<'arena> Parser<'_, '_, 'arena> {
                         Ok(symbol::RIGHT_SQUARE_BRACKET.as_op().as_superchar())
                     }
                     Token::Digit(digit) => Ok(digit.into()),
-                    Token::Prime => Ok(SuperChar::from_char('’')),
                     Token::Whitespace | Token::NonBreakingSpace => {
                         Ok(SuperChar::from_char(symbol::NO_BREAK_SPACE))
                     }
@@ -286,6 +284,8 @@ impl<'arena> Parser<'_, '_, 'arena> {
                             continue;
                         }
                     }
+                    Token::Prime(kind) => Ok(kind.to_ord().as_op().as_superchar()),
+
                     _ => Err(LatexErrKind::CouldNotExtractText),
                 }
             } else {

--- a/crates/math-core/src/token.rs
+++ b/crates/math-core/src/token.rs
@@ -2,7 +2,10 @@ use std::ops::Range;
 
 use strum_macros::IntoStaticStr;
 
-use mathml_renderer::symbol::{Bin, MathMLOperator, Op, OrdLike, Punct, Rel};
+use mathml_renderer::{
+    ast::Node,
+    symbol::{self, Bin, MathMLOperator, Op, OrdLike, Punct, Rel},
+};
 use mathml_renderer::{
     attribute::{FracAttr, HtmlTextSize, HtmlTextStyle, Notation, OpAttrs, Size, Style},
     super_char::SuperChar,
@@ -115,8 +118,8 @@ pub enum Token<'source> {
     Punctuation(Punct),
     /// A token corresponding to LaTeX's "mathinner" character class (class I).
     Inner(Op),
-    /// The character `'`.
-    Prime,
+    /// ', ′, ″, ‴, ‵, ‶, ‷, or ⁗ (in math mode)
+    Prime(PrimeKind),
     /// A token to force an operator to behave like a binary operator (mathbin).
     /// This is, for example, needed for `×`, which in LaTeX is a binary operator,
     /// but in MathML Core is a "big operator" (mathop).
@@ -280,6 +283,139 @@ pub enum LimitsKind {
     Display,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PrimeKind {
+    Single,
+    Double,
+    Triple,
+    Quadruple,
+    Reversed,
+    ReversedDouble,
+    ReversedTriple,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PrimeDirection {
+    Forward,
+    Reversed,
+}
+
+impl PrimeKind {
+    pub fn direction(self) -> PrimeDirection {
+        match self {
+            PrimeKind::Single | PrimeKind::Double | PrimeKind::Triple | PrimeKind::Quadruple => {
+                PrimeDirection::Forward
+            }
+            PrimeKind::Reversed | PrimeKind::ReversedDouble | PrimeKind::ReversedTriple => {
+                PrimeDirection::Reversed
+            }
+        }
+    }
+
+    pub fn count(self) -> usize {
+        match self {
+            PrimeKind::Single | PrimeKind::Reversed => 1,
+            PrimeKind::Double | PrimeKind::ReversedDouble => 2,
+            PrimeKind::Triple | PrimeKind::ReversedTriple => 3,
+            PrimeKind::Quadruple => 4,
+        }
+    }
+
+    pub const fn to_ord(self) -> OrdLike {
+        match self {
+            PrimeKind::Single => symbol::PRIME,
+            PrimeKind::Double => symbol::DOUBLE_PRIME,
+            PrimeKind::Triple => symbol::TRIPLE_PRIME,
+            PrimeKind::Quadruple => symbol::QUADRUPLE_PRIME,
+            PrimeKind::Reversed => symbol::REVERSED_PRIME,
+            PrimeKind::ReversedDouble => symbol::REVERSED_DOUBLE_PRIME,
+            PrimeKind::ReversedTriple => symbol::REVERSED_TRIPLE_PRIME,
+        }
+    }
+
+    pub const fn to_node(self) -> &'static Node<'static> {
+        match self {
+            PrimeKind::Single => {
+                &const {
+                    Node::Operator {
+                        op: symbol::PRIME.as_op(),
+                        attrs: OpAttrs::empty(),
+                        left: None,
+                        right: None,
+                        size: None,
+                    }
+                }
+            }
+            PrimeKind::Double => {
+                &const {
+                    Node::Operator {
+                        op: symbol::DOUBLE_PRIME.as_op(),
+                        attrs: OpAttrs::empty(),
+                        left: None,
+                        right: None,
+                        size: None,
+                    }
+                }
+            }
+            PrimeKind::Triple => {
+                &const {
+                    Node::Operator {
+                        op: symbol::TRIPLE_PRIME.as_op(),
+                        attrs: OpAttrs::empty(),
+                        left: None,
+                        right: None,
+                        size: None,
+                    }
+                }
+            }
+            PrimeKind::Quadruple => {
+                &const {
+                    Node::Operator {
+                        op: symbol::QUADRUPLE_PRIME.as_op(),
+                        attrs: OpAttrs::empty(),
+                        left: None,
+                        right: None,
+                        size: None,
+                    }
+                }
+            }
+            PrimeKind::Reversed => {
+                &const {
+                    Node::Operator {
+                        op: symbol::REVERSED_PRIME.as_op(),
+                        attrs: OpAttrs::empty(),
+                        left: None,
+                        right: None,
+                        size: None,
+                    }
+                }
+            }
+            PrimeKind::ReversedDouble => {
+                &const {
+                    Node::Operator {
+                        op: symbol::REVERSED_DOUBLE_PRIME.as_op(),
+                        attrs: OpAttrs::empty(),
+                        left: None,
+                        right: None,
+                        size: None,
+                    }
+                }
+            }
+            PrimeKind::ReversedTriple => {
+                &const {
+                    Node::Operator {
+                        op: symbol::REVERSED_TRIPLE_PRIME.as_op(),
+                        attrs: OpAttrs::empty(),
+                        left: None,
+                        right: None,
+                        size: None,
+                    }
+                }
+            }
+        }
+    }
+}
+
 #[cfg(target_arch = "wasm32")]
 static_assertions::assert_eq_size!(Token<'_>, [usize; 3]);
 #[cfg(target_arch = "wasm32")]
@@ -340,7 +476,7 @@ impl Token<'_> {
             | Sqrt
             | Transform(_)
             | Ord(_)
-            | Prime
+            | Prime(_)
             | Enclose(_)
             | Text(_)
             | Style(_)

--- a/crates/math-core/tests/conversion_test.rs
+++ b/crates/math-core/tests/conversion_test.rs
@@ -646,6 +646,15 @@ fn main() {
             "sideset_extras_3_underover",
             r#"\displaystyle{\sideset{a}{b}\int^5_6}"#,
         ),
+        ("unicode_prime", "a′"),
+        ("unicode_prime_2", "a″"),
+        ("unicode_prime_3", "a‴"),
+        ("unicode_prime_4", "a⁗"),
+        ("unicode_rprime_1", "a‵"),
+        ("unicode_rprime_2", "a‶"),
+        ("unicode_rprime_3", "a‷"),
+        ("unicode_primealooza", "a‷″″′″‷′′‶‵^a_b"),
+        ("unicode_primealooza_standalone", "‷″″′″‷′′‶‵"),
     ];
 
     let config = MathCoreConfig {

--- a/crates/math-core/tests/snapshots/conversion_test__quintuple_prime.snap
+++ b/crates/math-core/tests/snapshots/conversion_test__quintuple_prime.snap
@@ -7,9 +7,13 @@ expression: "f'''''"
         <mi>f</mi>
         <mrow>
             <mo>′</mo>
+            <mrow style="margin-left:-0.0833em;"></mrow>
             <mo>′</mo>
+            <mrow style="margin-left:-0.0833em;"></mrow>
             <mo>′</mo>
+            <mrow style="margin-left:-0.0833em;"></mrow>
             <mo>′</mo>
+            <mrow style="margin-left:-0.0833em;"></mrow>
             <mo>′</mo>
         </mrow>
     </msup>

--- a/crates/math-core/tests/snapshots/conversion_test__unicode_prime.snap
+++ b/crates/math-core/tests/snapshots/conversion_test__unicode_prime.snap
@@ -1,0 +1,10 @@
+---
+source: crates/math-core/tests/conversion_test.rs
+expression: a′
+---
+<math>
+    <msup>
+        <mi>a</mi>
+        <mo>′</mo>
+    </msup>
+</math>

--- a/crates/math-core/tests/snapshots/conversion_test__unicode_prime_2.snap
+++ b/crates/math-core/tests/snapshots/conversion_test__unicode_prime_2.snap
@@ -1,0 +1,10 @@
+---
+source: crates/math-core/tests/conversion_test.rs
+expression: a″
+---
+<math>
+    <msup>
+        <mi>a</mi>
+        <mo>″</mo>
+    </msup>
+</math>

--- a/crates/math-core/tests/snapshots/conversion_test__unicode_prime_3.snap
+++ b/crates/math-core/tests/snapshots/conversion_test__unicode_prime_3.snap
@@ -1,0 +1,10 @@
+---
+source: crates/math-core/tests/conversion_test.rs
+expression: a‴
+---
+<math>
+    <msup>
+        <mi>a</mi>
+        <mo>‴</mo>
+    </msup>
+</math>

--- a/crates/math-core/tests/snapshots/conversion_test__unicode_prime_4.snap
+++ b/crates/math-core/tests/snapshots/conversion_test__unicode_prime_4.snap
@@ -1,0 +1,10 @@
+---
+source: crates/math-core/tests/conversion_test.rs
+expression: a⁗
+---
+<math>
+    <msup>
+        <mi>a</mi>
+        <mo>⁗</mo>
+    </msup>
+</math>

--- a/crates/math-core/tests/snapshots/conversion_test__unicode_primealooza.snap
+++ b/crates/math-core/tests/snapshots/conversion_test__unicode_primealooza.snap
@@ -9,11 +9,17 @@ expression: a‷″″′″‷′′‶‵^a_b
         <mrow>
             <mo>‷</mo>
             <mo>′</mo>
+            <mrow style="margin-left:-0.0833em;"></mrow>
             <mo>′</mo>
+            <mrow style="margin-left:-0.0833em;"></mrow>
             <mo>′</mo>
+            <mrow style="margin-left:-0.0833em;"></mrow>
             <mo>′</mo>
+            <mrow style="margin-left:-0.0833em;"></mrow>
             <mo>′</mo>
+            <mrow style="margin-left:-0.0833em;"></mrow>
             <mo>′</mo>
+            <mrow style="margin-left:-0.0833em;"></mrow>
             <mo>′</mo>
             <mo>‷</mo>
             <mo>″</mo>

--- a/crates/math-core/tests/snapshots/conversion_test__unicode_primealooza.snap
+++ b/crates/math-core/tests/snapshots/conversion_test__unicode_primealooza.snap
@@ -1,0 +1,24 @@
+---
+source: crates/math-core/tests/conversion_test.rs
+expression: a‷″″′″‷′′‶‵^a_b
+---
+<math>
+    <msubsup>
+        <mi>a</mi>
+        <mi>b</mi>
+        <mrow>
+            <mo>‷</mo>
+            <mo>′</mo>
+            <mo>′</mo>
+            <mo>′</mo>
+            <mo>′</mo>
+            <mo>′</mo>
+            <mo>′</mo>
+            <mo>′</mo>
+            <mo>‷</mo>
+            <mo>″</mo>
+            <mo>‷</mo>
+            <mi>a</mi>
+        </mrow>
+    </msubsup>
+</math>

--- a/crates/math-core/tests/snapshots/conversion_test__unicode_primealooza_standalone.snap
+++ b/crates/math-core/tests/snapshots/conversion_test__unicode_primealooza_standalone.snap
@@ -8,11 +8,17 @@ expression: ‷″″′″‷′′‶‵
         <mrow>
             <mo>‷</mo>
             <mo>′</mo>
+            <mrow style="margin-left:-0.0833em;"></mrow>
             <mo>′</mo>
+            <mrow style="margin-left:-0.0833em;"></mrow>
             <mo>′</mo>
+            <mrow style="margin-left:-0.0833em;"></mrow>
             <mo>′</mo>
+            <mrow style="margin-left:-0.0833em;"></mrow>
             <mo>′</mo>
+            <mrow style="margin-left:-0.0833em;"></mrow>
             <mo>′</mo>
+            <mrow style="margin-left:-0.0833em;"></mrow>
             <mo>′</mo>
             <mo>‷</mo>
             <mo>″</mo>

--- a/crates/math-core/tests/snapshots/conversion_test__unicode_primealooza_standalone.snap
+++ b/crates/math-core/tests/snapshots/conversion_test__unicode_primealooza_standalone.snap
@@ -1,0 +1,22 @@
+---
+source: crates/math-core/tests/conversion_test.rs
+expression: ‷″″′″‷′′‶‵
+---
+<math>
+    <msup>
+        <mrow></mrow>
+        <mrow>
+            <mo>‷</mo>
+            <mo>′</mo>
+            <mo>′</mo>
+            <mo>′</mo>
+            <mo>′</mo>
+            <mo>′</mo>
+            <mo>′</mo>
+            <mo>′</mo>
+            <mo>‷</mo>
+            <mo>″</mo>
+            <mo>‷</mo>
+        </mrow>
+    </msup>
+</math>

--- a/crates/math-core/tests/snapshots/conversion_test__unicode_rprime_1.snap
+++ b/crates/math-core/tests/snapshots/conversion_test__unicode_rprime_1.snap
@@ -1,0 +1,10 @@
+---
+source: crates/math-core/tests/conversion_test.rs
+expression: a‵
+---
+<math>
+    <msup>
+        <mi>a</mi>
+        <mo>‵</mo>
+    </msup>
+</math>

--- a/crates/math-core/tests/snapshots/conversion_test__unicode_rprime_2.snap
+++ b/crates/math-core/tests/snapshots/conversion_test__unicode_rprime_2.snap
@@ -1,0 +1,10 @@
+---
+source: crates/math-core/tests/conversion_test.rs
+expression: a‶
+---
+<math>
+    <msup>
+        <mi>a</mi>
+        <mo>‶</mo>
+    </msup>
+</math>

--- a/crates/math-core/tests/snapshots/conversion_test__unicode_rprime_3.snap
+++ b/crates/math-core/tests/snapshots/conversion_test__unicode_rprime_3.snap
@@ -1,0 +1,10 @@
+---
+source: crates/math-core/tests/conversion_test.rs
+expression: a‷
+---
+<math>
+    <msup>
+        <mi>a</mi>
+        <mo>‷</mo>
+    </msup>
+</math>

--- a/crates/mathml-renderer/src/ast.rs
+++ b/crates/mathml-renderer/src/ast.rs
@@ -61,6 +61,8 @@ pub struct RowAttrs {
     pub style: Option<Style>,
     // `math-shift: compact;` CSS property
     pub math_shift_compact: bool,
+    // `margin_left` CSS property
+    pub margin_left: Option<MathSpacing>,
 }
 
 impl RowAttrs {
@@ -68,6 +70,7 @@ impl RowAttrs {
         color: None,
         style: None,
         math_shift_compact: false,
+        margin_left: None,
     };
 }
 
@@ -470,11 +473,12 @@ impl Node<'_> {
                         color,
                         style,
                         math_shift_compact,
+                        margin_left,
                     },
             } => {
                 write!(s, "<mrow")?;
 
-                if color.is_some() || math_shift_compact {
+                if color.is_some() || math_shift_compact || margin_left.is_some() {
                     write!(s, " style=\"")?;
                     if let Some((r, g, b)) = color {
                         write!(s, "color:#")?;
@@ -485,6 +489,9 @@ impl Node<'_> {
                     }
                     if math_shift_compact {
                         write!(s, "math-shift:compact;")?;
+                    }
+                    if let Some(margin) = margin_left {
+                        write!(s, "margin-left:{};", <&str>::from(margin))?;
                     }
                     write!(s, "\"")?;
                 }

--- a/crates/mathml-renderer/src/attribute.rs
+++ b/crates/mathml-renderer/src/attribute.rs
@@ -135,14 +135,20 @@ impl Style {
 #[derive(Clone, Copy, Debug, PartialEq, Eq, IntoStaticStr)]
 #[cfg_attr(feature = "serde", derive(Serialize))]
 pub enum MathSpacing {
+    /// -3/36 of an em/\quad
+    #[strum(serialize = "-0.0833em")]
+    NegativeOnePointFiveMu = -1,
     #[strum(serialize = "0")]
     Zero = 1,
+    /// 3/18 of an em/\quad
     #[strum(serialize = "0.1667em")]
-    ThreeMu, // 3/18 of an em/\quad
+    ThreeMu,
+    /// 4/18 of an em/\quad
     #[strum(serialize = "0.2222em")]
-    FourMu, // 4/18 of an em/\quad
+    FourMu,
+    /// 5/18 of an em/\quad
     #[strum(serialize = "0.2778em")]
-    FiveMu, // 5/18 of an em/\quad
+    FiveMu,
 }
 
 bitflags! {


### PR DESCRIPTION
Matches `unicode-math`.