### PR TITLE
Mark `\cramped` as not being rendered reliably

### DIFF
--- a/crates/math-core/src/commands.rs
+++ b/crates/math-core/src/commands.rs
@@ -260,7 +260,6 @@ static COMMANDS: phf::Map<&'static str, Token> = phf::phf_map! {
     "cong" => Relation(symbol::APPROXIMATELY_EQUAL_TO),
     "coprod" => Op(symbol::N_ARY_COPRODUCT),
     "copyright" => Letter(SuperChar::from_char(symbol::COPYRIGHT_SIGN), Mode::Math),
-    "cramped" => Cramped,
     "cup" => BinaryOp(symbol::UNION),
     "curlyeqprec" => Relation(symbol::EQUAL_TO_OR_PRECEDES),
     "curlyeqsucc" => Relation(symbol::EQUAL_TO_OR_SUCCEEDS),

--- a/crates/math-core/src/lexer.rs
+++ b/crates/math-core/src/lexer.rs
@@ -312,6 +312,7 @@ impl<'config, 'source> Lexer<'config, 'source> {
                 .is_some_and(|cfg| cfg.allow_unreliable_rendering)
             {
                 let tok = match cmd_string {
+                    "cramped" => Token::Cramped,
                     "widecheck" => Token::Accent(symbol::CARON, true, OpAttrs::STRETCHY_TRUE),
                     "widetilde" => {
                         Token::Accent(symbol::TILDE.as_op(), true, OpAttrs::STRETCHY_TRUE)

--- a/crates/math-core/tests/conversion_test.rs
+++ b/crates/math-core/tests/conversion_test.rs
@@ -665,6 +665,7 @@ fn main() {
 
     let config = MathCoreConfig {
         pretty_print: PrettyPrint::Always,
+        allow_unreliable_rendering: true,
         ..Default::default()
     };
     let converter = LatexToMathML::new(config).unwrap();

--- a/crates/math-core/tests/error_test.rs
+++ b/crates/math-core/tests/error_test.rs
@@ -133,6 +133,7 @@ fn main() {
 
     let config = MathCoreConfig {
         pretty_print: PrettyPrint::Never,
+        allow_unreliable_rendering: true,
         ..Default::default()
     };
     let converter = LatexToMathML::new(config).unwrap();


### PR DESCRIPTION
Unless you object, @Jules-Bertholet , I'm going to mark `\cramped` as not being reliably rendered by browsers. In my tests, actually none of the browsers seem to really do it correctly. I looked at the MathML Core spec a lot and it seems like it *should* work, but in practice it seems it doesn't.