### PR TITLE
Use `<merror>` with a custom style for unknown commands

### DIFF
--- a/crates/mathml-renderer/src/ast.rs
+++ b/crates/mathml-renderer/src/ast.rs
@@ -225,9 +225,8 @@ pub enum Node<'arena> {
         post: &'arena &'arena [MultiscriptPair<'arena>],
     },
     /// This node is used for displaying unknown commands.
-    /// We are not using `<merror>` here because it's rendered with a red border and a yellow
-    /// background, which is not desirable for our use case. We'll just render it as `<mtext>`
-    /// with a custom style.
+    /// It's `<merror>` with a custom CSS class
+    /// to override the default ugly yellow background
     UnknownCommand(&'arena str),
 }
 
@@ -708,7 +707,7 @@ impl<'state> Emitter<'state> {
             Node::UnknownCommand(cmd_name) => {
                 write!(
                     self.s,
-                    "<mtext style=\"color:#b22222\">\\{cmd_name}</mtext>"
+                    "<merror class=\"tex-error\"><mtext><code>\\{cmd_name}</code></mtext></merror>"
                 )?;
             }
         }

--- a/css/mathmlfixes.css
+++ b/css/mathmlfixes.css
@@ -1,3 +1,11 @@
+/* Style for unknown command; feel free to customize it */
+
+merror.tex-error {
+    /* border: 1px solid red; */ /* `merror` default */
+    background-color: unset; /* `merror` default is `lightYellow` */
+    color: #c22222; /* `merror` default is `unset` */
+}
+
 /* Styles for all browsers */
 
 mtd {

--- a/python/tests/test_all.py
+++ b/python/tests/test_all.py
@@ -138,7 +138,7 @@ def test_ignore_unknown_commands():
     converter = LatexToMathML(ignore_unknown_commands=True)
     assert (
         converter.convert_with_local_state("\\asdf <b>", displaystyle=False)
-        == r'<math><mtext style="color:#b22222">\asdf</mtext><mo>&lt;</mo><mi>b</mi><mo rspace="0">&gt;</mo></math>'
+        == r'<math><merror class="tex-error"><mtext><code>\asdf</code></mtext></merror><mo>&lt;</mo><mi>b</mi><mo rspace="0">&gt;</mo></math>'
     )
 
 


### PR DESCRIPTION
Using the semantically correct tag should help screen readers and such.