### PR TITLE
Use `math-core-unknown-cmd` as the CSS class

### DIFF
--- a/crates/mathml-renderer/src/ast.rs
+++ b/crates/mathml-renderer/src/ast.rs
@@ -707,7 +707,7 @@ impl<'state> Emitter<'state> {
             Node::UnknownCommand(cmd_name) => {
                 write!(
                     self.s,
-                    r#"<merror class="math-core-error"><mtext>\{cmd_name}</mtext></merror>"#
+                    r#"<merror class="math-core-unknown-cmd"><mtext>\{cmd_name}</mtext></merror>"#
                 )?;
             }
         }

--- a/css/mathmlfixes.css
+++ b/css/mathmlfixes.css
@@ -1,6 +1,6 @@
 /* Style for unknown command; feel free to customize it */
 
-merror.math-core-error {
+merror.math-core-unknown-cmd {
     border: unset; /* `merror` default is `1px solid red` */
     background-color: unset; /* `merror` default is `lightYellow` */
     color: #c00; /* `merror` default is `unset` */

--- a/python/tests/test_all.py
+++ b/python/tests/test_all.py
@@ -138,7 +138,7 @@ def test_ignore_unknown_commands():
     converter = LatexToMathML(ignore_unknown_commands=True)
     assert (
         converter.convert_with_local_state("\\asdf <b>", displaystyle=False)
-        == r'<math><merror class="math-core-error"><mtext>\asdf</mtext></merror><mo>&lt;</mo><mi>b</mi><mo rspace="0">&gt;</mo></math>'
+        == r'<math><merror class="math-core-unknown-cmd"><mtext>\asdf</mtext></merror><mo>&lt;</mo><mi>b</mi><mo rspace="0">&gt;</mo></math>'
     )
 
 


### PR DESCRIPTION
Turns out, we're already using `math-core-error`.